### PR TITLE
feat: type-based node colors, graph legend, and pipeline metadata

### DIFF
--- a/backend/src/graphrag_service/library/graph/rag_pipeline.py
+++ b/backend/src/graphrag_service/library/graph/rag_pipeline.py
@@ -32,6 +32,7 @@ class RAGState(TypedDict):
     subgraph: dict
     context: str
     answer: str
+    step_timings: dict[str, float]
 
 
 def build_rag_graph(
@@ -44,12 +45,22 @@ def build_rag_graph(
 ) -> StateGraph:
     """Build the RAG pipeline graph with injected functions."""
 
+    def _record_timing(state: RAGState, step: str, duration_ms: float) -> dict:
+        """Merge a step timing into the accumulated timings dict."""
+        existing = dict(state.get("step_timings") or {})
+        existing[step] = duration_ms
+        return existing
+
     def embed_step(state: RAGState) -> dict:
+        t0 = time.perf_counter()
         vector = _timed("embed", embed_fn, state["question"])
-        return {"query_vector": vector}
+        ms = round((time.perf_counter() - t0) * 1000, 1)
+        return {"query_vector": vector, "step_timings": _record_timing(state, "embed", ms)}
 
     def search_step(state: RAGState) -> dict:
+        t0 = time.perf_counter()
         results = _timed("vector_search", search_fn, state["query_vector"], top_k)
+        ms = round((time.perf_counter() - t0) * 1000, 1)
         seeds = [
             {
                 "id": r.id,
@@ -61,12 +72,14 @@ def build_rag_graph(
             for r in results
         ]
         logger.bind(count=len(seeds), top_scores=[s["score"] for s in seeds[:3]]).info("vector_search.results")
-        return {"seed_nodes": seeds}
+        return {"seed_nodes": seeds, "step_timings": _record_timing(state, "vector_search", ms)}
 
     def traverse_step(state: RAGState) -> dict:
         ids = [s["id"] for s in state["seed_nodes"]]
         logger.bind(seed_count=len(ids)).info("traverse.input")
+        t0 = time.perf_counter()
         nodes_dict, edges_list = _timed("traverse", traverse_fn, ids)
+        ms = round((time.perf_counter() - t0) * 1000, 1)
         logger.bind(nodes=len(nodes_dict), edges=len(edges_list)).info("traverse.results")
         return {
             "subgraph": {
@@ -74,23 +87,28 @@ def build_rag_graph(
                 "nodes": list(nodes_dict.values()),
                 "edges": edges_list,
                 "cypher_used": "neomodel VectorFilter + 2-hop traversal",
-            }
+            },
+            "step_timings": _record_timing(state, "traverse", ms),
         }
 
     def context_step(state: RAGState) -> dict:
+        t0 = time.perf_counter()
         context = _timed(
             "build_context",
             build_context_fn,
             state["seed_nodes"],
             state["subgraph"].get("edges", []),
         )
+        ms = round((time.perf_counter() - t0) * 1000, 1)
         logger.bind(context_len=len(context)).info("build_context.results")
-        return {"context": context}
+        return {"context": context, "step_timings": _record_timing(state, "build_context", ms)}
 
     def generate_step(state: RAGState) -> dict:
+        t0 = time.perf_counter()
         answer = _timed("generate", generate_fn, state["question"], state["context"])
+        ms = round((time.perf_counter() - t0) * 1000, 1)
         logger.bind(answer_len=len(answer)).info("generate.results")
-        return {"answer": answer}
+        return {"answer": answer, "step_timings": _record_timing(state, "generate", ms)}
 
     graph = StateGraph(RAGState)
     graph.add_node("embed", embed_step)

--- a/backend/src/graphrag_service/modules/rag/apiv1/handler.py
+++ b/backend/src/graphrag_service/modules/rag/apiv1/handler.py
@@ -13,7 +13,7 @@ from loguru import logger
 from graphrag_service.dbase.neo4j.client import Neo4jClient
 from graphrag_service.shared.exceptions import ServiceException
 
-from ..schemas import EdgeOut, QueryRequest, QueryResponse, SeedNodeOut
+from ..schemas import EdgeOut, PipelineMetadata, QueryRequest, QueryResponse, SeedNodeOut
 from ..usecase import RAGUseCase
 
 router = APIRouter()
@@ -31,31 +31,52 @@ async def query(req: QueryRequest, client: Neo4jClient = Depends(get_neo4j_clien
     usecase = RAGUseCase(client)
 
     t0 = time.time()
+    settings = get_settings()
     try:
         result = usecase.query(req.question)
         subgraph = result.get("subgraph", {})
         latency_ms = int((time.time() - t0) * 1000)
 
+        seed_nodes_out = [
+            SeedNodeOut(
+                id=s["id"], label=s["label"], name=s["name"], score=s["score"]
+            )
+            for s in subgraph.get("seed_nodes", [])
+        ]
+        nodes_out = subgraph.get("nodes", [])
+        edges_out = [
+            EdgeOut(
+                from_id=e["from_id"],
+                to_id=e["to_id"],
+                type=e["type"],
+                properties=e.get("properties", {}),
+            )
+            for e in subgraph.get("edges", [])
+        ]
+
+        metadata = PipelineMetadata(
+            llm_provider=settings.LLM_PROVIDER,
+            llm_model=settings.LLM_MODEL,
+            embedding_provider=settings.EMBEDDING_PROVIDER,
+            embedding_model=settings.EMBEDDING_MODEL,
+            embedding_dim=settings.EMBEDDING_DIM,
+            top_k=settings.TOP_K_SEED_NODES,
+            traversal_depth=settings.TRAVERSAL_DEPTH,
+            seed_count=len(seed_nodes_out),
+            node_count=len(nodes_out),
+            edge_count=len(edges_out),
+            context_length=len(result.get("context", "")),
+            step_timings=result.get("step_timings", {}),
+        )
+
         response = QueryResponse(
             answer=result["answer"],
-            seed_nodes=[
-                SeedNodeOut(
-                    id=s["id"], label=s["label"], name=s["name"], score=s["score"]
-                )
-                for s in subgraph.get("seed_nodes", [])
-            ],
-            nodes=subgraph.get("nodes", []),
-            edges=[
-                EdgeOut(
-                    from_id=e["from_id"],
-                    to_id=e["to_id"],
-                    type=e["type"],
-                    properties=e.get("properties", {}),
-                )
-                for e in subgraph.get("edges", [])
-            ],
+            seed_nodes=seed_nodes_out,
+            nodes=nodes_out,
+            edges=edges_out,
             cypher_used=subgraph.get("cypher_used", ""),
             latency_ms=latency_ms,
+            metadata=metadata,
         )
         logger.bind(
             latency_ms=latency_ms,

--- a/backend/src/graphrag_service/modules/rag/schemas.py
+++ b/backend/src/graphrag_service/modules/rag/schemas.py
@@ -29,6 +29,26 @@ class EdgeOut(BaseModel):
     properties: dict = Field(default_factory=dict, description="Edge properties")
 
 
+class PipelineMetadata(BaseModel):
+    """Detailed pipeline execution metadata for evaluation."""
+
+    llm_provider: str = Field(..., description="LLM provider name")
+    llm_model: str = Field(..., description="LLM model name")
+    embedding_provider: str = Field(..., description="Embedding provider name")
+    embedding_model: str = Field(..., description="Embedding model name")
+    embedding_dim: int = Field(..., description="Embedding dimension")
+    top_k: int = Field(..., description="Top-K seed nodes requested")
+    traversal_depth: int = Field(..., description="Graph traversal depth")
+    seed_count: int = Field(..., description="Number of seed nodes found")
+    node_count: int = Field(..., description="Total nodes in subgraph")
+    edge_count: int = Field(..., description="Total edges in subgraph")
+    context_length: int = Field(..., description="Context string length in characters")
+    step_timings: dict[str, float] = Field(
+        default_factory=dict,
+        description="Per-step durations in ms (embed, vector_search, traverse, build_context, generate)",
+    )
+
+
 class QueryResponse(BaseModel):
     """RAG query response with answer and graph context."""
 
@@ -42,3 +62,6 @@ class QueryResponse(BaseModel):
     )
     cypher_used: str = Field(..., description="Cypher query used for traversal")
     latency_ms: int = Field(..., description="Total latency in milliseconds")
+    metadata: PipelineMetadata | None = Field(
+        None, description="Detailed pipeline execution metadata"
+    )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import { CypherPanel } from "@/components/CypherPanel";
 import { NodeDetailPanel } from "@/components/NodeDetailPanel";
 import { queryGraph } from "@/lib/api";
 import { ApiError } from "@/types/api";
-import type { SeedNode, GraphNode, GraphEdge } from "@/types/api";
+import type { SeedNode, GraphNode, GraphEdge, PipelineMetadata } from "@/types/api";
 import { AlertCircle, Network } from "lucide-react";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { StatusBadges } from "@/components/StatusBadges";
@@ -26,6 +26,7 @@ export default function App() {
   const [edges, setEdges] = useState<GraphEdge[]>([]);
   const [cypher, setCypher] = useState("");
   const [latencyMs, setLatencyMs] = useState<number | null>(null);
+  const [metadata, setMetadata] = useState<PipelineMetadata | null>(null);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
   const handleSubmit = async (question: string) => {
@@ -37,6 +38,7 @@ export default function App() {
     setEdges([]);
     setCypher("");
     setLatencyMs(null);
+    setMetadata(null);
     setSelectedNodeId(null);
 
     try {
@@ -47,6 +49,7 @@ export default function App() {
       setEdges(response.edges);
       setCypher(response.cypher_used);
       setLatencyMs(response.latency_ms);
+      setMetadata(response.metadata);
     } catch (err) {
       if (err instanceof ApiError) {
         setError(`API error (${err.statusCode}): ${err.detail}`);
@@ -113,6 +116,7 @@ export default function App() {
               seedNodes={seedNodes}
               isLoading={isLoading}
               latencyMs={latencyMs ?? undefined}
+              metadata={metadata}
               exampleQuestions={EXAMPLE_QUESTIONS}
             />
           </div>

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Send, Loader2, Sparkles, Clock } from "lucide-react";
-import type { SeedNode } from "@/types/api";
+import { Send, Loader2, Sparkles, Clock, Brain, Search, GitBranch, FileText, Zap, ChevronDown, ChevronRight } from "lucide-react";
+import type { SeedNode, PipelineMetadata } from "@/types/api";
 
 const BADGE_COLORS: Record<string, string> = {
   Paper: "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20",
@@ -17,6 +17,7 @@ interface ChatPanelProps {
   seedNodes: SeedNode[];
   isLoading: boolean;
   latencyMs?: number;
+  metadata: PipelineMetadata | null;
   exampleQuestions: string[];
 }
 
@@ -26,9 +27,11 @@ export function ChatPanel({
   seedNodes,
   isLoading,
   latencyMs,
+  metadata,
   exampleQuestions,
 }: ChatPanelProps) {
   const [question, setQuestion] = useState("");
+  const [showMetadata, setShowMetadata] = useState(true);
 
   const handleSubmit = (q: string) => {
     if (!q.trim()) return;
@@ -98,10 +101,104 @@ export function ChatPanel({
             <p className="text-[13px] leading-relaxed whitespace-pre-wrap text-foreground/90">
               {answer}
             </p>
-            {latencyMs !== undefined && (
-              <div className="flex items-center gap-1 text-[11px] text-muted-foreground/70">
-                <Clock size={10} />
-                <span className="tabular-nums">{latencyMs}ms</span>
+
+            {/* Pipeline Metadata */}
+            {(latencyMs !== undefined || metadata) && (
+              <div className="pt-2 border-t border-border/30 space-y-2">
+                <button
+                  onClick={() => setShowMetadata((v) => !v)}
+                  className="flex items-center gap-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {showMetadata ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+                  <span>Pipeline Details</span>
+                  {latencyMs !== undefined && (
+                    <span className="ml-auto tabular-nums font-normal normal-case tracking-normal text-muted-foreground/70">
+                      {latencyMs >= 1000 ? `${(latencyMs / 1000).toFixed(1)}s` : `${latencyMs}ms`}
+                    </span>
+                  )}
+                </button>
+
+                {showMetadata && metadata && (
+                  <div className="space-y-2.5 text-[11px]">
+                    {/* Models */}
+                    <div className="flex items-start gap-2">
+                      <Brain size={11} className="text-purple-500 mt-0.5 shrink-0" />
+                      <div className="space-y-0.5 min-w-0">
+                        <div className="flex items-center gap-1.5">
+                          <span className="text-muted-foreground">LLM:</span>
+                          <span className="font-medium text-foreground/90">{metadata.llm_model}</span>
+                          <span className="text-muted-foreground/60">({metadata.llm_provider})</span>
+                        </div>
+                        <div className="flex items-center gap-1.5">
+                          <span className="text-muted-foreground">Embed:</span>
+                          <span className="font-medium text-foreground/90">{metadata.embedding_model}</span>
+                          <span className="text-muted-foreground/60">({metadata.embedding_provider}, {metadata.embedding_dim}d)</span>
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Graph stats */}
+                    <div className="flex items-start gap-2">
+                      <GitBranch size={11} className="text-emerald-500 mt-0.5 shrink-0" />
+                      <div className="flex flex-wrap gap-x-3 gap-y-0.5">
+                        <span>
+                          <span className="text-muted-foreground">Seeds:</span>{" "}
+                          <span className="font-medium tabular-nums">{metadata.seed_count}</span>
+                          <span className="text-muted-foreground/60"> / top-{metadata.top_k}</span>
+                        </span>
+                        <span>
+                          <span className="text-muted-foreground">Nodes:</span>{" "}
+                          <span className="font-medium tabular-nums">{metadata.node_count}</span>
+                        </span>
+                        <span>
+                          <span className="text-muted-foreground">Edges:</span>{" "}
+                          <span className="font-medium tabular-nums">{metadata.edge_count}</span>
+                        </span>
+                        <span>
+                          <span className="text-muted-foreground">Depth:</span>{" "}
+                          <span className="font-medium tabular-nums">{metadata.traversal_depth}</span>
+                        </span>
+                      </div>
+                    </div>
+
+                    {/* Context */}
+                    <div className="flex items-start gap-2">
+                      <FileText size={11} className="text-blue-500 mt-0.5 shrink-0" />
+                      <span>
+                        <span className="text-muted-foreground">Context:</span>{" "}
+                        <span className="font-medium tabular-nums">{metadata.context_length.toLocaleString()}</span>
+                        <span className="text-muted-foreground/60"> chars</span>
+                      </span>
+                    </div>
+
+                    {/* Step timings */}
+                    {Object.keys(metadata.step_timings).length > 0 && (
+                      <div className="flex items-start gap-2">
+                        <Zap size={11} className="text-amber-500 mt-0.5 shrink-0" />
+                        <div className="flex-1 space-y-1">
+                          {Object.entries(metadata.step_timings).map(([step, ms]) => {
+                            const totalMs = latencyMs || Object.values(metadata.step_timings).reduce((a, b) => a + b, 0);
+                            const pct = totalMs > 0 ? (ms / totalMs) * 100 : 0;
+                            return (
+                              <div key={step} className="flex items-center gap-2">
+                                <span className="text-muted-foreground w-24 shrink-0">{step.replace(/_/g, " ")}</span>
+                                <div className="flex-1 h-1.5 rounded-full bg-secondary overflow-hidden">
+                                  <div
+                                    className="h-full rounded-full bg-primary/50"
+                                    style={{ width: `${Math.min(pct, 100)}%` }}
+                                  />
+                                </div>
+                                <span className="tabular-nums font-medium w-16 text-right shrink-0">
+                                  {ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms.toFixed(0)}ms`}
+                                </span>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/frontend/src/components/GraphViewer.tsx
+++ b/frontend/src/components/GraphViewer.tsx
@@ -12,15 +12,14 @@ interface GraphViewerProps {
 }
 
 const NODE_COLORS: Record<string, string> = {
-  Paper: "#3b82f6",
-  Method: "#22c55e",
-  Task: "#a855f7",
-  Dataset: "#f97316",
+  Paper: "#3b82f6",   // blue
+  Method: "#22c55e",  // green
+  Task: "#a855f7",    // purple
+  Dataset: "#f97316", // orange
 };
 
-const SEED_COLOR = "#f97316";
 const DEFAULT_COLOR = "#64748b";
-const REL_COLOR = "rgba(148, 163, 184, 0.4)";
+const REL_COLOR = "rgba(148, 163, 184, 0.5)";
 
 export function GraphViewer({ nodes, edges, seedNodeIds, onNodeSelect }: GraphViewerProps) {
   const nvlRef = useRef(null);
@@ -32,11 +31,12 @@ export function GraphViewer({ nodes, edges, seedNodeIds, onNodeSelect }: GraphVi
         const isSeed = seedNodeIds.has(id);
         const label = n.label || "";
         const name = n.name || n.title || id;
+        const color = NODE_COLORS[label] ?? DEFAULT_COLOR;
 
         return {
           id,
-          size: isSeed ? 30 : 20,
-          color: isSeed ? SEED_COLOR : (NODE_COLORS[label] ?? DEFAULT_COLOR),
+          size: isSeed ? 35 : 22,
+          color,
           caption: name.length > 28 ? name.slice(0, 26) + "\u2026" : name,
           activated: isSeed,
         };
@@ -52,7 +52,7 @@ export function GraphViewer({ nodes, edges, seedNodeIds, onNodeSelect }: GraphVi
         to: e.to_id,
         caption: e.type,
         color: REL_COLOR,
-        width: 1,
+        width: 1.5,
       })),
     [edges],
   );
@@ -85,8 +85,15 @@ export function GraphViewer({ nodes, edges, seedNodeIds, onNodeSelect }: GraphVi
     );
   }
 
+  // Compute label distribution for legend
+  const labelCounts: Record<string, number> = {};
+  for (const n of nodes) {
+    const lbl = n.label || "Unknown";
+    labelCounts[lbl] = (labelCounts[lbl] || 0) + 1;
+  }
+
   return (
-    <div className="w-full h-full nvl-container">
+    <div className="w-full h-full nvl-container relative">
       <InteractiveNvlWrapper
         ref={nvlRef}
         nodes={nvlNodes}
@@ -105,6 +112,24 @@ export function GraphViewer({ nodes, edges, seedNodeIds, onNodeSelect }: GraphVi
           onLayoutDone: handleLayoutDone,
         }}
       />
+
+      {/* Legend */}
+      <div className="absolute bottom-3 left-3 flex flex-col gap-1 px-2.5 py-2 rounded-lg border border-border/50 bg-card/90 backdrop-blur-sm shadow-sm">
+        {Object.entries(labelCounts).map(([label, count]) => (
+          <div key={label} className="flex items-center gap-2 text-[10px]">
+            <div
+              className="w-2.5 h-2.5 rounded-full shrink-0"
+              style={{ backgroundColor: NODE_COLORS[label] ?? DEFAULT_COLOR }}
+            />
+            <span className="text-foreground/80 font-medium">{label}</span>
+            <span className="text-muted-foreground/60 tabular-nums">{count}</span>
+          </div>
+        ))}
+        <div className="flex items-center gap-2 text-[10px] pt-0.5 border-t border-border/30">
+          <div className="w-2.5 h-2.5 rounded-full shrink-0 border-2 border-foreground/40 bg-transparent" />
+          <span className="text-muted-foreground">= seed node (larger)</span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -41,6 +41,23 @@ export interface GraphEdge {
   properties: Record<string, string>;
 }
 
+// Pipeline metadata for evaluation
+
+export interface PipelineMetadata {
+  llm_provider: string;
+  llm_model: string;
+  embedding_provider: string;
+  embedding_model: string;
+  embedding_dim: number;
+  top_k: number;
+  traversal_depth: number;
+  seed_count: number;
+  node_count: number;
+  edge_count: number;
+  context_length: number;
+  step_timings: Record<string, number>;
+}
+
 // Main response
 
 export interface QueryResponse {
@@ -50,6 +67,7 @@ export interface QueryResponse {
   edges: GraphEdge[];
   cypher_used: string;
   latency_ms: number;
+  metadata: PipelineMetadata | null;
 }
 
 // /api/v1/graph/schema


### PR DESCRIPTION
## Summary
- Node colors by type (Paper=blue, Method=green, Task=purple, Dataset=orange) instead of uniform orange
- Seed nodes differentiated by larger size (35px vs 22px)
- Graph legend overlay showing node type colors and counts
- Backend PipelineMetadata with model info, graph stats, per-step timings
- Collapsible Pipeline Details panel with visual timing bars

## Test plan
- [ ] Verify different node colors per type
- [ ] Verify seed nodes are larger
- [ ] Check legend shows correct counts
- [ ] Confirm Pipeline Details with model info and timing bars