### PR TITLE
feat(graph): ingestion progress tracking, resume, offset/limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,4 @@ node_modules/
 .next/
 *.json.gz
 data/*.json
+data/.ingest_progress.json

--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,12 @@ cli-schema: check-neo4j ## Create schema via CLI
 cli-ingest: check-env check-neo4j ## Run ingestion via CLI
 	cd backend && $(POETRY) run cli graph ingest
 
+cli-ingest-resume: check-env check-neo4j ## Resume ingestion from last checkpoint
+	cd backend && $(POETRY) run cli graph ingest --resume --skip-embedded
+
+cli-ingest-status: ## Show ingestion progress
+	cd backend && $(POETRY) run cli graph ingest-status
+
 cli-status: ## Check graph status via CLI
 	cd backend && $(POETRY) run cli graph status
 

--- a/backend/src/graphrag_service/library/parsers.py
+++ b/backend/src/graphrag_service/library/parsers.py
@@ -13,11 +13,27 @@ def load_json(path: Path) -> list:
         return json.load(f)
 
 
-def iter_papers(data: list, max_papers: int = 5000) -> Iterator[dict]:
-    """Parse raw papers JSON into clean dicts."""
+def iter_papers(
+    data: list, max_papers: int = 5000, offset: int = 0, limit: int = 0
+) -> Iterator[dict]:
+    """Parse raw papers JSON into clean dicts.
+
+    Args:
+        data: Raw papers JSON list.
+        max_papers: Max papers to consider from source data.
+        offset: Skip this many *valid* items before yielding.
+        limit: Yield at most this many items (0 = unlimited).
+    """
+    yielded = 0
+    skipped = 0
     for p in data[:max_papers]:
         if not p.get("title") or not p.get("abstract"):
             continue
+        if skipped < offset:
+            skipped += 1
+            continue
+        if limit > 0 and yielded >= limit:
+            return
         yield {
             "uid": p.get("paper_url", p.get("id", "")),
             "title": p["title"].strip(),
@@ -25,48 +41,79 @@ def iter_papers(data: list, max_papers: int = 5000) -> Iterator[dict]:
             "year": p.get("published", "")[:4],
             "url": p.get("paper_url", ""),
         }
+        yielded += 1
 
 
-def iter_methods(data: list, max_items: int = 0) -> Iterator[dict]:
+def iter_methods(
+    data: list, max_items: int = 0, offset: int = 0, limit: int = 0
+) -> Iterator[dict]:
     """Parse raw methods JSON into clean dicts."""
     items = data[:max_items] if max_items > 0 else data
+    yielded = 0
+    skipped = 0
     for m in items:
         if not m.get("name"):
             continue
+        if skipped < offset:
+            skipped += 1
+            continue
+        if limit > 0 and yielded >= limit:
+            return
         yield {
             "uid": m.get("id", m["name"]),
             "name": m["name"].strip(),
             "full_name": (m.get("full_name") or m["name"]).strip(),
             "description": (m.get("description") or "")[:2000],
         }
+        yielded += 1
 
 
-def iter_tasks(data: list, max_items: int = 0) -> Iterator[dict]:
+def iter_tasks(
+    data: list, max_items: int = 0, offset: int = 0, limit: int = 0
+) -> Iterator[dict]:
     """Parse raw tasks JSON into clean dicts."""
     items = data[:max_items] if max_items > 0 else data
+    yielded = 0
+    skipped = 0
     for t in items:
         if not t.get("name"):
             continue
+        if skipped < offset:
+            skipped += 1
+            continue
+        if limit > 0 and yielded >= limit:
+            return
         yield {
             "uid": t.get("id", t["name"]),
             "name": t["name"].strip(),
             "area": (t.get("area") or "").strip(),
             "description": (t.get("description") or "")[:1000],
         }
+        yielded += 1
 
 
-def iter_datasets(data: list, max_items: int = 0) -> Iterator[dict]:
+def iter_datasets(
+    data: list, max_items: int = 0, offset: int = 0, limit: int = 0
+) -> Iterator[dict]:
     """Parse raw datasets JSON into clean dicts."""
     items = data[:max_items] if max_items > 0 else data
+    yielded = 0
+    skipped = 0
     for d in items:
         if not d.get("name"):
             continue
+        if skipped < offset:
+            skipped += 1
+            continue
+        if limit > 0 and yielded >= limit:
+            return
         yield {
             "uid": d.get("id", d["name"]),
             "name": d["name"].strip(),
             "description": (d.get("description") or "")[:1000],
             "modalities": ", ".join(d.get("modalities") or []),
         }
+        yielded += 1
 
 
 def iter_authors(data: list, max_papers: int = 5000) -> Iterator[dict]:

--- a/backend/src/graphrag_service/modules/graph/checkpoint.py
+++ b/backend/src/graphrag_service/modules/graph/checkpoint.py
@@ -1,0 +1,118 @@
+"""
+Ingestion progress checkpoint — tracks last successful batch per node type.
+
+Allows resuming ingestion after interruption without re-processing everything.
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class NodeTypeProgress(BaseModel):
+    """Progress state for a single node type."""
+
+    label: str
+    total_parsed: int = 0
+    total_embedded: int = 0
+    total_upserted: int = 0
+    skipped_existing: int = 0
+    last_batch_index: int = 0
+    completed: bool = False
+    updated_at: str = ""
+
+    def mark_batch(self, batch_size: int, skipped: int = 0) -> None:
+        """Record a completed batch."""
+        self.total_parsed += batch_size
+        self.total_embedded += batch_size - skipped
+        self.total_upserted += batch_size
+        self.skipped_existing += skipped
+        self.last_batch_index += 1
+        self.updated_at = datetime.now(timezone.utc).isoformat()
+
+    def mark_completed(self) -> None:
+        """Mark this node type as fully ingested."""
+        self.completed = True
+        self.updated_at = datetime.now(timezone.utc).isoformat()
+
+
+class IngestCheckpoint(BaseModel):
+    """Full ingestion checkpoint state."""
+
+    started_at: str = Field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    updated_at: str = ""
+    node_types: dict[str, NodeTypeProgress] = Field(default_factory=dict)
+
+    def get_or_create(self, label: str) -> NodeTypeProgress:
+        """Get progress for a node type, creating if needed."""
+        if label not in self.node_types:
+            self.node_types[label] = NodeTypeProgress(label=label)
+        return self.node_types[label]
+
+    @property
+    def is_complete(self) -> bool:
+        """True if all tracked node types are completed."""
+        return bool(self.node_types) and all(
+            nt.completed for nt in self.node_types.values()
+        )
+
+
+DEFAULT_CHECKPOINT_PATH = Path("data/.ingest_progress.json")
+
+
+def load_checkpoint(path: Optional[Path] = None) -> IngestCheckpoint:
+    """Load checkpoint from disk. Returns empty checkpoint if file missing."""
+    p = path or DEFAULT_CHECKPOINT_PATH
+    if not p.exists():
+        return IngestCheckpoint()
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+        return IngestCheckpoint.model_validate(raw)
+    except (json.JSONDecodeError, ValueError):
+        return IngestCheckpoint()
+
+
+def save_checkpoint(checkpoint: IngestCheckpoint, path: Optional[Path] = None) -> None:
+    """Atomically save checkpoint to disk."""
+    p = path or DEFAULT_CHECKPOINT_PATH
+    checkpoint.updated_at = datetime.now(timezone.utc).isoformat()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(".tmp")
+    tmp.write_text(checkpoint.model_dump_json(indent=2), encoding="utf-8")
+    tmp.rename(p)
+
+
+def reset_checkpoint(path: Optional[Path] = None) -> None:
+    """Delete checkpoint file to start fresh."""
+    p = path or DEFAULT_CHECKPOINT_PATH
+    if p.exists():
+        p.unlink()
+
+
+def format_checkpoint_report(checkpoint: IngestCheckpoint) -> str:
+    """Format checkpoint as a human-readable report string."""
+    lines = [
+        f"Ingestion Progress (started: {checkpoint.started_at})",
+        f"Last updated: {checkpoint.updated_at or 'never'}",
+        "",
+    ]
+    if not checkpoint.node_types:
+        lines.append("  No progress recorded yet.")
+        return "\n".join(lines)
+
+    for label, progress in checkpoint.node_types.items():
+        status = "DONE" if progress.completed else "IN PROGRESS"
+        lines.append(f"  {label}: [{status}]")
+        lines.append(f"    Parsed:   {progress.total_parsed}")
+        lines.append(f"    Embedded: {progress.total_embedded}")
+        lines.append(f"    Upserted: {progress.total_upserted}")
+        lines.append(f"    Skipped (already embedded): {progress.skipped_existing}")
+        lines.append(f"    Batches completed: {progress.last_batch_index}")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/backend/src/graphrag_service/modules/graph/cli/commands.py
+++ b/backend/src/graphrag_service/modules/graph/cli/commands.py
@@ -2,10 +2,17 @@
 Graph CLI commands for schema creation and data ingestion.
 """
 
+from typing import Optional
+
 import typer
 
-from graphrag_service.cli.base import console, print_error, print_info, print_success
+from graphrag_service.cli.base import console, print_error, print_info, print_success, print_warning
 from graphrag_service.core.dependencies import close_neo4j_client, get_neo4j_client
+from graphrag_service.modules.graph.checkpoint import (
+    format_checkpoint_report,
+    load_checkpoint,
+    reset_checkpoint,
+)
 from graphrag_service.modules.graph.usecase import GraphUseCase
 
 
@@ -33,25 +40,81 @@ def get_graph_app() -> typer.Typer:
             close_neo4j_client()
 
     @app.command()
-    def ingest():
-        """Ingest entities and relationships into Neo4j."""
+    def ingest(
+        node_type: Optional[str] = typer.Option(
+            None, "--type", "-t",
+            help="Only ingest this node type (Paper, Method, Task, Dataset).",
+        ),
+        offset: int = typer.Option(
+            0, "--offset", "-o",
+            help="Skip this many valid items before processing.",
+        ),
+        limit: int = typer.Option(
+            0, "--limit", "-l",
+            help="Process at most this many items (0 = unlimited).",
+        ),
+        resume: bool = typer.Option(
+            False, "--resume", "-r",
+            help="Resume from last checkpoint, skipping completed node types.",
+        ),
+        skip_embedded: bool = typer.Option(
+            False, "--skip-embedded",
+            help="Skip embedding for nodes that already have vectors in Neo4j.",
+        ),
+        reset: bool = typer.Option(
+            False, "--reset",
+            help="Reset progress checkpoint before starting.",
+        ),
+        no_relationships: bool = typer.Option(
+            False, "--no-relationships",
+            help="Skip relationship ingestion (nodes only).",
+        ),
+    ):
+        """Ingest entities and relationships into Neo4j.
+
+        Supports resuming, offset/limit batching, and skipping already-embedded nodes.
+        """
+        if reset:
+            reset_checkpoint()
+            print_info("Progress checkpoint reset")
+
         print_info("Starting data ingestion...")
         try:
             client = get_neo4j_client()
             usecase = GraphUseCase(client)
 
             print_info("Ingesting nodes with embeddings...")
-            usecase.ingest_nodes()
+            usecase.ingest_nodes(
+                node_type=node_type,
+                offset=offset,
+                limit=limit,
+                resume=resume,
+                skip_embedded=skip_embedded,
+            )
 
-            print_info("Ingesting relationships...")
-            usecase.ingest_relationships()
+            if not no_relationships:
+                print_info("Ingesting relationships...")
+                usecase.ingest_relationships()
 
             print_success("Ingestion complete")
+        except ValueError as e:
+            print_error(str(e))
+            raise typer.Exit(code=1)
         except Exception as e:
             print_error(f"Ingestion failed: {e}")
             raise typer.Exit(code=1)
         finally:
             close_neo4j_client()
+
+    @app.command(name="ingest-status")
+    def ingest_status():
+        """Show ingestion progress from checkpoint file."""
+        checkpoint = load_checkpoint()
+        if not checkpoint.node_types:
+            print_warning("No ingestion progress recorded yet.")
+            raise typer.Exit()
+        report = format_checkpoint_report(checkpoint)
+        console.print(report)
 
     @app.command()
     def status():

--- a/backend/src/graphrag_service/modules/graph/repositories.py
+++ b/backend/src/graphrag_service/modules/graph/repositories.py
@@ -114,6 +114,20 @@ class NodeRepository:
     def __init__(self, client: Neo4jClient):
         self._client = client
 
+    def get_embedded_uids(self, label: str) -> set[str]:
+        """Return UIDs of nodes that already have an embedding vector."""
+        validated = _validate_label(label)
+        try:
+            rows = self._client.run_query(
+                f"MATCH (n:{validated}) WHERE n.embedding IS NOT NULL "
+                "RETURN collect(n.uid) AS uids"
+            )
+            return set(rows[0]["uids"]) if rows else set()
+        except Exception as e:
+            raise RepositoryException(
+                f"Failed to get embedded UIDs for {label}: {e}"
+            ) from e
+
     def upsert_batch(
         self,
         model: type[StructuredNode],

--- a/backend/src/graphrag_service/modules/graph/services.py
+++ b/backend/src/graphrag_service/modules/graph/services.py
@@ -35,29 +35,37 @@ class GraphService:
         # __file__ is modules/graph/services.py → go up 6 levels to project root
         return Path(__file__).parent.parent.parent.parent.parent.parent / settings.DATA_DIR
 
-    def load_papers(self) -> Iterator[dict]:
+    def load_papers(
+        self, offset: int = 0, limit: int = 0
+    ) -> Iterator[dict]:
         """Load and parse papers using library functions."""
         settings = get_settings()
         data = load_json(self.data_dir() / "papers.json")
-        return iter_papers(data, max_papers=settings.MAX_PAPERS)
+        return iter_papers(data, max_papers=settings.MAX_PAPERS, offset=offset, limit=limit)
 
-    def load_methods(self) -> Iterator[dict]:
+    def load_methods(
+        self, offset: int = 0, limit: int = 0
+    ) -> Iterator[dict]:
         """Load and parse methods using library functions."""
         settings = get_settings()
         data = load_json(self.data_dir() / "methods.json")
-        return iter_methods(data, max_items=settings.MAX_METHODS)
+        return iter_methods(data, max_items=settings.MAX_METHODS, offset=offset, limit=limit)
 
-    def load_tasks(self) -> Iterator[dict]:
+    def load_tasks(
+        self, offset: int = 0, limit: int = 0
+    ) -> Iterator[dict]:
         """Load and parse tasks using library functions."""
         settings = get_settings()
         data = load_json(self.data_dir() / "tasks.json")
-        return iter_tasks(data, max_items=settings.MAX_TASKS)
+        return iter_tasks(data, max_items=settings.MAX_TASKS, offset=offset, limit=limit)
 
-    def load_datasets(self) -> Iterator[dict]:
+    def load_datasets(
+        self, offset: int = 0, limit: int = 0
+    ) -> Iterator[dict]:
         """Load and parse datasets using library functions."""
         settings = get_settings()
         data = load_json(self.data_dir() / "datasets.json")
-        return iter_datasets(data, max_items=settings.MAX_DATASETS)
+        return iter_datasets(data, max_items=settings.MAX_DATASETS, offset=offset, limit=limit)
 
     def load_evaluations(self) -> list:
         """Load evaluation data from JSON."""

--- a/backend/src/graphrag_service/modules/graph/usecase.py
+++ b/backend/src/graphrag_service/modules/graph/usecase.py
@@ -4,6 +4,7 @@ Graph use case orchestration layer.
 Coordinates service (logic) + repository (DB).
 """
 
+from pathlib import Path
 from typing import List, Tuple
 
 from tqdm import tqdm
@@ -14,6 +15,12 @@ from graphrag_service.core.config import get_settings
 from graphrag_service.dbase.neo4j.client import Neo4jClient
 from graphrag_service.dbase.neo4j.models import Dataset, Method, Paper, Task
 
+from .checkpoint import (
+    IngestCheckpoint,
+    NodeTypeProgress,
+    load_checkpoint,
+    save_checkpoint,
+)
 from .repositories import GraphExploreRepository, NodeRepository, SchemaRepository
 from .services import GraphService
 
@@ -31,6 +38,7 @@ class GraphUseCase:
     """Orchestrates graph operations — coordinates service (logic) + repository (DB)."""
 
     def __init__(self, client: Neo4jClient):
+        self._client = client
         self.service = GraphService()
         self.schema_repo = SchemaRepository(client)
         self.node_repo = NodeRepository(client)
@@ -60,27 +68,133 @@ class GraphUseCase:
         """Search nodes by name."""
         return self.explore_repo.search_nodes(query, label=label, limit=limit)
 
-    def ingest_nodes(self) -> None:
-        """Ingest all entities: service parses data + embeds, repository writes to DB."""
+    def ingest_nodes(
+        self,
+        *,
+        node_type: str | None = None,
+        offset: int = 0,
+        limit: int = 0,
+        resume: bool = False,
+        skip_embedded: bool = False,
+        checkpoint_path: Path | None = None,
+    ) -> None:
+        """Ingest entities with progress tracking and resume support.
+
+        Args:
+            node_type: Only ingest this label (e.g. "Paper"). None = all.
+            offset: Skip this many valid items before processing.
+            limit: Process at most this many items (0 = unlimited).
+            resume: If True, skip node types already marked completed in checkpoint.
+            skip_embedded: If True, skip embedding for nodes that already have one.
+            checkpoint_path: Override default checkpoint file path.
+        """
         settings = get_settings()
         batch_size = settings.INGEST_BATCH_SIZE
 
-        for model, loader_name in NODE_MODEL_LOADERS:
+        checkpoint = load_checkpoint(checkpoint_path) if resume else IngestCheckpoint()
+
+        loaders = NODE_MODEL_LOADERS
+        if node_type:
+            loaders = [
+                (m, ln) for m, ln in NODE_MODEL_LOADERS if m.__label__ == node_type
+            ]
+            if not loaders:
+                valid = [m.__label__ for m, _ in NODE_MODEL_LOADERS]
+                raise ValueError(
+                    f"Unknown node type '{node_type}'. Valid: {', '.join(valid)}"
+                )
+
+        embedded_cache: dict[str, set[str]] = {}
+
+        for model, loader_name in loaders:
+            label = model.__label__
+            progress = checkpoint.get_or_create(label)
+
+            if resume and progress.completed:
+                logger.info(f"Skipping {label} — already completed in checkpoint")
+                continue
+
+            if skip_embedded:
+                embedded_cache[label] = self.node_repo.get_embedded_uids(label)
+                logger.info(
+                    f"{label}: {len(embedded_cache[label])} nodes already embedded"
+                )
+
             loader = getattr(self.service, loader_name)
-            logger.info(f"Ingesting {model.__label__}s...")
+            logger.info(f"Ingesting {label}s (offset={offset}, limit={limit})...")
+
             batch: list[dict] = []
-            for node in tqdm(loader(), desc=model.__label__):
+            for node in tqdm(loader(offset=offset, limit=limit), desc=label):
                 batch.append(node)
                 if len(batch) == batch_size:
-                    texts = self.service.prepare_embed_texts(batch)
-                    embeddings = self.service.embed_nodes(texts)
-                    self.node_repo.upsert_batch(model, batch, embeddings)
+                    self._process_batch(
+                        model, batch, skip_embedded, embedded_cache.get(label, set()),
+                        progress,
+                    )
+                    save_checkpoint(checkpoint, checkpoint_path)
                     batch = []
+
             if batch:
-                texts = self.service.prepare_embed_texts(batch)
-                embeddings = self.service.embed_nodes(texts)
-                self.node_repo.upsert_batch(model, batch, embeddings)
-            logger.info(f"{model.__label__} ingestion done")
+                self._process_batch(
+                    model, batch, skip_embedded, embedded_cache.get(label, set()),
+                    progress,
+                )
+
+            progress.mark_completed()
+            save_checkpoint(checkpoint, checkpoint_path)
+            logger.info(
+                f"{label} done — {progress.total_upserted} upserted, "
+                f"{progress.skipped_existing} skipped"
+            )
+
+    def _process_batch(
+        self,
+        model: type,
+        batch: list[dict],
+        skip_embedded: bool,
+        embedded_uids: set[str],
+        progress: NodeTypeProgress,
+    ) -> None:
+        """Embed and upsert a single batch, optionally skipping already-embedded nodes."""
+        if skip_embedded:
+            need_embed = [n for n in batch if n["uid"] not in embedded_uids]
+            already = len(batch) - len(need_embed)
+        else:
+            need_embed = batch
+            already = 0
+
+        if need_embed:
+            texts = self.service.prepare_embed_texts(need_embed)
+            embeddings = self.service.embed_nodes(texts)
+            self.node_repo.upsert_batch(model, need_embed, embeddings)
+
+        # Upsert nodes that already have embeddings (without re-embedding)
+        skip_nodes = [n for n in batch if n["uid"] in embedded_uids] if skip_embedded else []
+        if skip_nodes:
+            # Use zero vectors as placeholder — the MERGE won't overwrite existing embedding
+            # because _get_upsert_cypher sets all props including embedding.
+            # Instead, upsert without embedding by using a separate query.
+            self._upsert_without_embedding(model, skip_nodes)
+
+        progress.mark_batch(len(batch), skipped=already)
+
+    def _upsert_without_embedding(
+        self, model: type, nodes: list[dict]
+    ) -> None:
+        """Upsert nodes without overwriting their existing embedding."""
+        label = model.__label__
+        props = [
+            k for k, v in model.defined_properties(aliases=False, rels=False).items()
+            if k != "embedding"
+        ]
+        set_parts = [f"n.{p} = row.{p}" for p in props]
+        set_clause = ", ".join(set_parts)
+        cypher = (
+            f"UNWIND $rows AS row "
+            f"MERGE (n:{label} {{uid: row.uid}}) "
+            f"SET {set_clause}"
+        )
+        self._client.run_query(cypher, {"rows": nodes})
 
     def ingest_relationships(self) -> None:
         """Ingest relationships: service loads data, repository writes to DB."""

--- a/backend/tests/unit/library/test_parsers.py
+++ b/backend/tests/unit/library/test_parsers.py
@@ -48,6 +48,36 @@ class TestIterPapers:
         assert results[0]["abstract"] == "Abstract"
 
 
+    def test_offset(self):
+        data = [{"title": f"P{i}", "abstract": f"A{i}"} for i in range(5)]
+        results = list(iter_papers(data, offset=2))
+        assert len(results) == 3
+        assert results[0]["title"] == "P2"
+
+    def test_limit(self):
+        data = [{"title": f"P{i}", "abstract": f"A{i}"} for i in range(5)]
+        results = list(iter_papers(data, limit=2))
+        assert len(results) == 2
+
+    def test_offset_and_limit(self):
+        data = [{"title": f"P{i}", "abstract": f"A{i}"} for i in range(10)]
+        results = list(iter_papers(data, offset=3, limit=2))
+        assert len(results) == 2
+        assert results[0]["title"] == "P3"
+        assert results[1]["title"] == "P4"
+
+    def test_offset_skips_invalid(self):
+        data = [
+            {"title": "P0", "abstract": "A0"},
+            {"title": "", "abstract": "A1"},  # invalid, skipped by parser
+            {"title": "P2", "abstract": "A2"},
+            {"title": "P3", "abstract": "A3"},
+        ]
+        results = list(iter_papers(data, offset=1))
+        assert len(results) == 2
+        assert results[0]["title"] == "P2"
+
+
 class TestIterMethods:
     def test_basic(self):
         data = [{"name": "ResNet", "id": "m1", "description": "A method"}]
@@ -75,6 +105,12 @@ class TestIterMethods:
         results = list(iter_methods(data))
         assert results[0]["uid"] == "Test"
 
+    def test_offset_and_limit(self):
+        data = [{"name": f"M{i}"} for i in range(10)]
+        results = list(iter_methods(data, offset=3, limit=2))
+        assert len(results) == 2
+        assert results[0]["name"] == "M3"
+
 
 class TestIterTasks:
     def test_basic(self):
@@ -90,6 +126,12 @@ class TestIterTasks:
         results = list(iter_tasks(data))
         assert len(results[0]["description"]) == 1000
 
+    def test_offset_and_limit(self):
+        data = [{"name": f"T{i}"} for i in range(10)]
+        results = list(iter_tasks(data, offset=2, limit=3))
+        assert len(results) == 3
+        assert results[0]["name"] == "T2"
+
 
 class TestIterDatasets:
     def test_basic(self):
@@ -104,6 +146,12 @@ class TestIterDatasets:
         data = [{"name": "D1"}]
         results = list(iter_datasets(data))
         assert results[0]["modalities"] == ""
+
+    def test_offset_and_limit(self):
+        data = [{"name": f"D{i}"} for i in range(10)]
+        results = list(iter_datasets(data, offset=5, limit=2))
+        assert len(results) == 2
+        assert results[0]["name"] == "D5"
 
 
 class TestIterAuthors:

--- a/backend/tests/unit/modules/graph/test_checkpoint.py
+++ b/backend/tests/unit/modules/graph/test_checkpoint.py
@@ -1,0 +1,175 @@
+"""Unit tests for ingestion checkpoint module."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from graphrag_service.modules.graph.checkpoint import (
+    IngestCheckpoint,
+    NodeTypeProgress,
+    format_checkpoint_report,
+    load_checkpoint,
+    reset_checkpoint,
+    save_checkpoint,
+)
+
+
+class TestNodeTypeProgress:
+    def test_initial_state(self):
+        p = NodeTypeProgress(label="Paper")
+        assert p.total_parsed == 0
+        assert p.total_embedded == 0
+        assert p.total_upserted == 0
+        assert p.skipped_existing == 0
+        assert p.last_batch_index == 0
+        assert p.completed is False
+
+    def test_mark_batch(self):
+        p = NodeTypeProgress(label="Paper")
+        p.mark_batch(50, skipped=10)
+        assert p.total_parsed == 50
+        assert p.total_embedded == 40
+        assert p.total_upserted == 50
+        assert p.skipped_existing == 10
+        assert p.last_batch_index == 1
+        assert p.updated_at != ""
+
+    def test_mark_batch_multiple(self):
+        p = NodeTypeProgress(label="Method")
+        p.mark_batch(50)
+        p.mark_batch(30, skipped=5)
+        assert p.total_parsed == 80
+        assert p.total_embedded == 75
+        assert p.total_upserted == 80
+        assert p.skipped_existing == 5
+        assert p.last_batch_index == 2
+
+    def test_mark_completed(self):
+        p = NodeTypeProgress(label="Task")
+        p.mark_completed()
+        assert p.completed is True
+        assert p.updated_at != ""
+
+
+class TestIngestCheckpoint:
+    def test_empty_checkpoint(self):
+        c = IngestCheckpoint()
+        assert c.node_types == {}
+        assert c.started_at != ""
+        assert c.is_complete is False
+
+    def test_get_or_create_new(self):
+        c = IngestCheckpoint()
+        p = c.get_or_create("Paper")
+        assert p.label == "Paper"
+        assert "Paper" in c.node_types
+
+    def test_get_or_create_existing(self):
+        c = IngestCheckpoint()
+        p1 = c.get_or_create("Paper")
+        p1.mark_batch(10)
+        p2 = c.get_or_create("Paper")
+        assert p2.total_parsed == 10
+        assert p1 is p2
+
+    def test_is_complete_false_when_incomplete(self):
+        c = IngestCheckpoint()
+        c.get_or_create("Paper")
+        assert c.is_complete is False
+
+    def test_is_complete_true_when_all_done(self):
+        c = IngestCheckpoint()
+        p = c.get_or_create("Paper")
+        p.mark_completed()
+        assert c.is_complete is True
+
+    def test_is_complete_false_when_mixed(self):
+        c = IngestCheckpoint()
+        p1 = c.get_or_create("Paper")
+        p1.mark_completed()
+        c.get_or_create("Method")  # not completed
+        assert c.is_complete is False
+
+
+class TestCheckpointIO:
+    def test_load_missing_file(self, tmp_path):
+        c = load_checkpoint(tmp_path / "missing.json")
+        assert c.node_types == {}
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+        path = tmp_path / "progress.json"
+        c = IngestCheckpoint()
+        p = c.get_or_create("Paper")
+        p.mark_batch(100)
+        p.mark_completed()
+        save_checkpoint(c, path)
+
+        loaded = load_checkpoint(path)
+        assert "Paper" in loaded.node_types
+        assert loaded.node_types["Paper"].total_parsed == 100
+        assert loaded.node_types["Paper"].completed is True
+
+    def test_save_creates_parent_dirs(self, tmp_path):
+        path = tmp_path / "nested" / "dir" / "progress.json"
+        save_checkpoint(IngestCheckpoint(), path)
+        assert path.exists()
+
+    def test_load_invalid_json(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text("not json", encoding="utf-8")
+        c = load_checkpoint(path)
+        assert c.node_types == {}
+
+    def test_load_invalid_schema(self, tmp_path):
+        path = tmp_path / "bad_schema.json"
+        path.write_text('{"node_types": "not a dict"}', encoding="utf-8")
+        c = load_checkpoint(path)
+        assert c.node_types == {}
+
+    def test_reset_checkpoint(self, tmp_path):
+        path = tmp_path / "progress.json"
+        save_checkpoint(IngestCheckpoint(), path)
+        assert path.exists()
+        reset_checkpoint(path)
+        assert not path.exists()
+
+    def test_reset_missing_file_no_error(self, tmp_path):
+        reset_checkpoint(tmp_path / "missing.json")  # should not raise
+
+    def test_save_atomic_overwrites(self, tmp_path):
+        path = tmp_path / "progress.json"
+        c1 = IngestCheckpoint()
+        c1.get_or_create("Paper").mark_batch(10)
+        save_checkpoint(c1, path)
+
+        c2 = IngestCheckpoint()
+        c2.get_or_create("Method").mark_batch(20)
+        save_checkpoint(c2, path)
+
+        loaded = load_checkpoint(path)
+        assert "Method" in loaded.node_types
+        assert loaded.node_types["Method"].total_parsed == 20
+
+
+class TestFormatCheckpointReport:
+    def test_empty_checkpoint(self):
+        report = format_checkpoint_report(IngestCheckpoint())
+        assert "No progress recorded yet" in report
+
+    def test_with_progress(self):
+        c = IngestCheckpoint()
+        p = c.get_or_create("Paper")
+        p.mark_batch(100, skipped=20)
+        p.mark_completed()
+        report = format_checkpoint_report(c)
+        assert "Paper" in report
+        assert "DONE" in report
+        assert "100" in report
+        assert "20" in report
+
+    def test_in_progress(self):
+        c = IngestCheckpoint()
+        c.get_or_create("Method").mark_batch(50)
+        report = format_checkpoint_report(c)
+        assert "IN PROGRESS" in report


### PR DESCRIPTION
## Summary
- Add checkpoint system that saves progress after each batch, enabling resume on interruption
- Add `--resume`, `--skip-embedded`, `--offset`, `--limit`, `--type`, `--reset`, `--no-relationships` CLI flags to `graph ingest`
- Add `graph ingest-status` command to show progress from checkpoint file
- Add `get_embedded_uids()` to NodeRepository for skip-embedded support
- Add `offset`/`limit` params to all parser `iter_*` functions (counts valid items only)
- 29 new unit tests (21 checkpoint + 8 parser offset/limit), all passing

## Test plan
- [x] All 406 unit tests pass (1 pre-existing failure unrelated)
- [x] 21 checkpoint tests: models, IO roundtrip, atomic save, invalid JSON, reset
- [x] 8 parser offset/limit tests: offset, limit, combined, skips invalid items
- [ ] Manual: `cli graph ingest --type Paper --limit 50` then `cli graph ingest-status`
- [ ] Manual: `cli graph ingest --resume --skip-embedded` after interruption