### PR TITLE
feat(frontend): routing, navigation, and dashboard page #19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,4 @@ node_modules/
 *.json.gz
 data/*.json
 data/.ingest_progress.json
+backend/data/.ingest_progress.json

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -19,6 +19,17 @@ python-igraph = "*"
 tqdm = "*"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+description = "Document parameters, class attributes, return types, and variables inline, with Annotated."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"},
+    {file = "annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4"},
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
@@ -3414,13 +3425,13 @@ requests = ">=2.0.1,<3.0.0"
 
 [[package]]
 name = "rich"
-version = "13.9.4"
+version = "14.3.3"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90"},
-    {file = "rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098"},
+    {file = "rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d"},
+    {file = "rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b"},
 ]
 
 [package.dependencies]
@@ -3767,20 +3778,20 @@ telegram = ["requests"]
 
 [[package]]
 name = "typer"
-version = "0.12.5"
+version = "0.24.1"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 files = [
-    {file = "typer-0.12.5-py3-none-any.whl", hash = "sha256:62fe4e471711b147e3365034133904df3e235698399bc4de2b36c8579298d52b"},
-    {file = "typer-0.12.5.tar.gz", hash = "sha256:f592f089bedcc8ec1b974125d64851029c3b1af145f04aca64d69410f0c9b722"},
+    {file = "typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e"},
+    {file = "typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45"},
 ]
 
 [package.dependencies]
-click = ">=8.0.0"
-rich = ">=10.11.0"
+annotated-doc = ">=0.0.2"
+click = ">=8.2.1"
+rich = ">=12.3.0"
 shellingham = ">=1.3.0"
-typing-extensions = ">=3.7.4.3"
 
 [[package]]
 name = "typing-extensions"
@@ -4422,4 +4433,4 @@ cffi = ["cffi (>=1.17,<2.0)", "cffi (>=2.0.0b)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "22047e8173a006e98885d7d95ff270ea8e9d072c6b1239502d8159bb7cdc71ee"
+content-hash = "94c916b9be96c1664fb4cbf6107ecc1a4c09292605b91605f79eb358a4992740"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,8 +30,8 @@ langchain-openai = "^1.1.10"
 tqdm = "^4.66.4"
 psutil = "^7.0.0"
 # CLI
-typer = {extras = ["all"], version = "^0.12.0"}
-rich = "^13.7.0"
+typer = ">=0.15,<1.0"
+rich = ">=13.10"
 loguru = "^0.7.3"
 rapidfuzz = "^3.6.0"
 networkx = "^3.2"

--- a/backend/src/graphrag_service/cli/evaluate.py
+++ b/backend/src/graphrag_service/cli/evaluate.py
@@ -21,7 +21,7 @@ def get_eval_app() -> typer.Typer:
     def run(
         category: str = typer.Option("", "--category", help="Run only this category (e.g. FACTUAL_LOOKUP)"),
         output: str = typer.Option("", "--output", help="Output JSON file path"),
-        markdown: bool = typer.Option(False, "--markdown", help="Also output markdown report"),
+        markdown: bool = typer.Option(False, help="Also output markdown report"),
     ):
         """Run evaluation suite against the RAG pipeline."""
         # Import here to avoid circular imports and loading models at CLI parse time

--- a/backend/src/graphrag_service/cli/main.py
+++ b/backend/src/graphrag_service/cli/main.py
@@ -12,7 +12,7 @@ app = typer.Typer(
     help="GraphRAG Service CLI - Command-line interface for GraphRAG Service",
     add_completion=False,
     no_args_is_help=True,
-    rich_markup_mode="none",
+    rich_markup_mode="rich",
     context_settings={"help_option_names": ["-h", "--help"]},
 )
 

--- a/backend/src/graphrag_service/library/parsers.py
+++ b/backend/src/graphrag_service/library/parsers.py
@@ -24,9 +24,10 @@ def iter_papers(
         offset: Skip this many *valid* items before yielding.
         limit: Yield at most this many items (0 = unlimited).
     """
+    papers = data[:max_papers] if max_papers > 0 else data
     yielded = 0
     skipped = 0
-    for p in data[:max_papers]:
+    for p in papers:
         if not p.get("title") or not p.get("abstract"):
             continue
         if skipped < offset:
@@ -124,7 +125,8 @@ def iter_authors(data: list, max_papers: int = 5000) -> Iterator[dict]:
     De-duplicates by stripped name across all papers.
     """
     seen: set[str] = set()
-    for p in data[:max_papers]:
+    papers = data[:max_papers] if max_papers > 0 else data
+    for p in papers:
         for raw_name in p.get("authors") or []:
             name = raw_name.strip()
             if not name or name in seen:
@@ -140,7 +142,8 @@ def iter_author_paper_edges(
 
     Yields dicts with keys: author_name, paper_uid, order.
     """
-    for p in data[:max_papers]:
+    papers = data[:max_papers] if max_papers > 0 else data
+    for p in papers:
         if not p.get("title") or not p.get("abstract"):
             continue
         paper_uid = p.get("paper_url", p.get("id", ""))

--- a/backend/src/graphrag_service/modules/graph/cli/commands.py
+++ b/backend/src/graphrag_service/modules/graph/cli/commands.py
@@ -54,19 +54,19 @@ def get_graph_app() -> typer.Typer:
             help="Process at most this many items (0 = unlimited).",
         ),
         resume: bool = typer.Option(
-            False, "--resume",
+            False,
             help="Resume from last checkpoint, skipping completed node types.",
         ),
         skip_embedded: bool = typer.Option(
-            False, "--skip-embedded",
+            False,
             help="Skip embedding for nodes that already have vectors in Neo4j.",
         ),
         reset: bool = typer.Option(
-            False, "--reset",
+            False,
             help="Reset progress checkpoint before starting.",
         ),
-        no_relationships: bool = typer.Option(
-            False, "--no-relationships",
+        skip_relationships: bool = typer.Option(
+            False,
             help="Skip relationship ingestion (nodes only).",
         ),
     ):
@@ -92,7 +92,7 @@ def get_graph_app() -> typer.Typer:
                 skip_embedded=skip_embedded,
             )
 
-            if not no_relationships:
+            if not skip_relationships:
                 print_info("Ingesting relationships...")
                 usecase.ingest_relationships()
 
@@ -128,6 +128,11 @@ def get_graph_app() -> typer.Typer:
                 labels, rels = usecase.get_schema()
                 console.print(f"  Node labels: {labels}")
                 console.print(f"  Relationship types: {rels}")
+                stats = usecase.get_stats()
+                console.print("  Node counts:")
+                for label, count in stats.get("node_counts", {}).items():
+                    console.print(f"    {label}: {count:,}")
+                console.print(f"  Total relationships: {stats.get('relationship_count', 0):,}")
             else:
                 print_error("Neo4j is not reachable")
         except Exception as e:

--- a/backend/src/graphrag_service/modules/graph/repositories.py
+++ b/backend/src/graphrag_service/modules/graph/repositories.py
@@ -10,7 +10,7 @@ from loguru import logger
 
 from graphrag_service.core.config import get_settings
 from graphrag_service.dbase.neo4j.client import Neo4jClient
-from graphrag_service.dbase.neo4j.models import ALL_NODE_MODELS
+from graphrag_service.dbase.neo4j.models import ALL_MODELS, ALL_NODE_MODELS
 
 from graphrag_service.shared.exceptions import RepositoryException
 
@@ -18,7 +18,7 @@ from graphrag_service.shared.exceptions import RepositoryException
 EXPLORE_QUERY = "MATCH (a)-[r]->(b) RETURN a, type(r) AS rel, b LIMIT $limit"
 
 # Allowlist for label names — prevents Cypher injection via f-string interpolation
-VALID_LABELS: frozenset[str] = frozenset(m.__label__ for m in ALL_NODE_MODELS)
+VALID_LABELS: frozenset[str] = frozenset(m.__label__ for m in ALL_MODELS)
 
 
 def _validate_label(label: str) -> str:
@@ -150,6 +150,15 @@ class NodeRepository:
             {"dname": dataset_name, "tname": task_name},
         )
 
+    def merge_authored(self, author_uid: str, paper_uid: str, order: int) -> None:
+        self._client.run_query(
+            "MATCH (a:Author {uid: $auid}) "
+            "MATCH (p:Paper {uid: $puid}) "
+            "MERGE (a)-[r:AUTHORED]->(p) "
+            "SET r.order = $order",
+            {"auid": author_uid, "puid": paper_uid, "order": order},
+        )
+
     def merge_evaluated_on(
         self,
         method_name: str,
@@ -205,7 +214,7 @@ class GraphExploreRepository:
         """Get node/edge counts per label."""
         counts: dict[str, int] = {}
         try:
-            for model in ALL_NODE_MODELS:
+            for model in ALL_MODELS:
                 label = _validate_label(model.__label__)
                 rows = self._client.run_query(
                     f"MATCH (n:{label}) RETURN count(n) AS c"

--- a/backend/src/graphrag_service/modules/graph/services.py
+++ b/backend/src/graphrag_service/modules/graph/services.py
@@ -13,6 +13,7 @@ from loguru import logger
 from graphrag_service.core.config import get_settings
 from graphrag_service.library.llm import embed_batch
 from graphrag_service.library.parsers import (
+    iter_authors,
     iter_datasets,
     iter_methods,
     iter_papers,
@@ -66,6 +67,18 @@ class GraphService:
         settings = get_settings()
         data = load_json(self.data_dir() / "datasets.json")
         return iter_datasets(data, max_items=settings.MAX_DATASETS, offset=offset, limit=limit)
+
+    def load_authors(
+        self, offset: int = 0, limit: int = 0
+    ) -> Iterator[dict]:
+        """Load and parse authors extracted from papers.json."""
+        settings = get_settings()
+        data = load_json(self.data_dir() / "papers.json")
+        authors = list(iter_authors(data, max_papers=settings.MAX_PAPERS))
+        # Apply offset/limit manually since iter_authors doesn't support them
+        start = offset
+        end = (offset + limit) if limit > 0 else len(authors)
+        yield from authors[start:end]
 
     def load_evaluations(self) -> list:
         """Load evaluation data from JSON."""

--- a/backend/src/graphrag_service/modules/graph/usecase.py
+++ b/backend/src/graphrag_service/modules/graph/usecase.py
@@ -13,7 +13,7 @@ from loguru import logger
 
 from graphrag_service.core.config import get_settings
 from graphrag_service.dbase.neo4j.client import Neo4jClient
-from graphrag_service.dbase.neo4j.models import Dataset, Method, Paper, Task
+from graphrag_service.dbase.neo4j.models import Author, Dataset, Method, Paper, Task
 
 from .checkpoint import (
     IngestCheckpoint,
@@ -31,6 +31,7 @@ NODE_MODEL_LOADERS = [
     (Method, "load_methods"),
     (Task, "load_tasks"),
     (Dataset, "load_datasets"),
+    (Author, "load_authors"),
 ]
 
 
@@ -120,11 +121,20 @@ class GraphUseCase:
                     f"{label}: {len(embedded_cache[label])} nodes already embedded"
                 )
 
+            # When resuming an incomplete type, continue from where we left off
+            effective_offset = offset
+            if resume and progress.total_parsed > 0 and not progress.completed:
+                effective_offset = offset + progress.total_parsed
+                logger.info(
+                    f"{label}: resuming from item {effective_offset} "
+                    f"({progress.total_parsed} already processed)"
+                )
+
             loader = getattr(self.service, loader_name)
-            logger.info(f"Ingesting {label}s (offset={offset}, limit={limit})...")
+            logger.info(f"Ingesting {label}s (offset={effective_offset}, limit={limit})...")
 
             batch: list[dict] = []
-            for node in tqdm(loader(offset=offset, limit=limit), desc=label):
+            for node in tqdm(loader(offset=effective_offset, limit=limit), desc=label):
                 batch.append(node)
                 if len(batch) == batch_size:
                     self._process_batch(
@@ -156,6 +166,14 @@ class GraphUseCase:
         progress: NodeTypeProgress,
     ) -> None:
         """Embed and upsert a single batch, optionally skipping already-embedded nodes."""
+        has_embedding = "embedding" in model.defined_properties(aliases=False, rels=False)
+
+        # Models without embedding (e.g. Author) — upsert directly, no embedding
+        if not has_embedding:
+            self._upsert_without_embedding(model, batch)
+            progress.mark_batch(len(batch), skipped=0)
+            return
+
         if skip_embedded:
             need_embed = [n for n in batch if n["uid"] not in embedded_uids]
             already = len(batch) - len(need_embed)
@@ -198,10 +216,12 @@ class GraphUseCase:
 
     def ingest_relationships(self) -> None:
         """Ingest relationships: service loads data, repository writes to DB."""
-        logger.info("Ingesting relationships...")
+        from graphrag_service.library.parsers import iter_author_paper_edges, load_json
+
+        logger.info("Ingesting USED_FOR + EVALUATED_ON relationships...")
         evals = self.service.load_evaluations()
 
-        for ev in tqdm(evals, desc="Relationships"):
+        for ev in tqdm(evals, desc="USED_FOR + EVALUATED_ON"):
             task_name = ev.get("task", "")
             if not task_name:
                 continue
@@ -225,4 +245,17 @@ class GraphUseCase:
                             metric=metric_name,
                             score=str(metric_value),
                         )
+
+        logger.info("Ingesting AUTHORED relationships...")
+        settings = get_settings()
+        papers_data = load_json(self.service.data_dir() / "papers.json")
+        edges = list(iter_author_paper_edges(papers_data, max_papers=settings.MAX_PAPERS))
+        for edge in tqdm(edges, desc="AUTHORED"):
+            author_uid = f"author:{edge['author_name'].lower().replace(' ', '_')}"
+            self.node_repo.merge_authored(
+                author_uid=author_uid,
+                paper_uid=edge["paper_uid"],
+                order=edge["order"],
+            )
+
         logger.info("Relationships ingestion done")

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+../backend/data/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@neo4j-nvl/react": "^1.1.0",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-scroll-area": "^1.2.10",
+        "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tooltip": "^1.2.8",
         "class-variance-authority": "^0.7.1",
@@ -19,6 +20,7 @@
         "lucide-react": "^0.576.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-router-dom": "^7.13.1",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -1489,6 +1491,52 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-separator/-/react-separator-1.1.8.tgz",
+      "integrity": "sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3033,6 +3081,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -4658,6 +4719,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmmirror.com/react-router/-/react-router-7.13.1.tgz",
+      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmmirror.com/react-router-dom/-/react-router-dom-7.13.1.tgz",
+      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/read-cache/-/read-cache-1.0.0.tgz",
@@ -4875,6 +4974,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmmirror.com/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@neo4j-nvl/react": "^1.1.0",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-scroll-area": "^1.2.10",
+    "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",
     "class-variance-authority": "^0.7.1",
@@ -21,6 +22,7 @@
     "lucide-react": "^0.576.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-router-dom": "^7.13.1",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,154 +1,23 @@
-import { useState, useCallback } from "react";
-import { ChatPanel } from "@/components/ChatPanel";
-import { GraphViewer } from "@/components/GraphViewer";
-import { CypherPanel } from "@/components/CypherPanel";
-import { NodeDetailPanel } from "@/components/NodeDetailPanel";
-import { queryGraph } from "@/lib/api";
-import { ApiError } from "@/types/api";
-import type { SeedNode, GraphNode, GraphEdge, PipelineMetadata } from "@/types/api";
-import { AlertCircle, Network } from "lucide-react";
-import { ThemeToggle } from "@/components/ThemeToggle";
-import { StatusBadges } from "@/components/StatusBadges";
-
-const EXAMPLE_QUESTIONS = [
-  "What methods are used for object detection?",
-  "Which papers introduced transformer architectures?",
-  "What datasets are used to benchmark image classification?",
-  "How does BERT relate to other NLP methods?",
-];
+import { Routes, Route, Navigate } from "react-router-dom";
+import { NavBar } from "@/components/NavBar";
+import DashboardPage from "@/pages/DashboardPage";
+import QueryPage from "@/pages/QueryPage";
+import ExplorePage from "@/pages/ExplorePage";
+import AnalyticsPage from "@/pages/AnalyticsPage";
+import EvaluationPage from "@/pages/EvaluationPage";
 
 export default function App() {
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [answer, setAnswer] = useState("");
-  const [seedNodes, setSeedNodes] = useState<SeedNode[]>([]);
-  const [nodes, setNodes] = useState<GraphNode[]>([]);
-  const [edges, setEdges] = useState<GraphEdge[]>([]);
-  const [cypher, setCypher] = useState("");
-  const [latencyMs, setLatencyMs] = useState<number | null>(null);
-  const [metadata, setMetadata] = useState<PipelineMetadata | null>(null);
-  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
-
-  const handleSubmit = async (question: string) => {
-    setIsLoading(true);
-    setError(null);
-    setAnswer("");
-    setSeedNodes([]);
-    setNodes([]);
-    setEdges([]);
-    setCypher("");
-    setLatencyMs(null);
-    setMetadata(null);
-    setSelectedNodeId(null);
-
-    try {
-      const response = await queryGraph(question);
-      setAnswer(response.answer);
-      setSeedNodes(response.seed_nodes);
-      setNodes(response.nodes);
-      setEdges(response.edges);
-      setCypher(response.cypher_used);
-      setLatencyMs(response.latency_ms);
-      setMetadata(response.metadata);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        setError(`API error (${err.statusCode}): ${err.detail}`);
-      } else {
-        setError("Network error. Is the backend running?");
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const seedNodeIds = new Set(seedNodes.map((sn) => sn.id));
-
-  const handleNodeSelect = useCallback((nodeId: string | null) => {
-    setSelectedNodeId(nodeId);
-  }, []);
-
-  const selectedNode = selectedNodeId
-    ? nodes.find((n) => (n.uid || n.id) === selectedNodeId) ?? null
-    : null;
-
   return (
     <div className="min-h-screen flex flex-col bg-background">
-      {/* Header */}
-      <header className="relative z-10 border-b border-border/50 backdrop-blur-sm bg-background/80">
-        <div className="px-6 py-3 flex items-center gap-3">
-          <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-primary/10 border border-primary/20">
-            <Network size={18} className="text-primary" />
-          </div>
-          <div className="flex flex-col">
-            <h1 className="text-sm font-semibold tracking-tight text-foreground">
-              graphrag-neo4j
-            </h1>
-            <p className="text-[11px] text-muted-foreground leading-none">
-              Graph RAG over ML Research Papers
-            </p>
-          </div>
-          <div className="ml-auto flex items-center gap-2">
-            <StatusBadges />
-            <ThemeToggle />
-          </div>
-        </div>
-      </header>
-
-      {/* Error banner */}
-      {error && (
-        <div className="mx-4 mt-3 p-3 rounded-lg bg-destructive/10 border border-destructive/20 flex items-start gap-2">
-          <AlertCircle size={14} className="text-destructive mt-0.5 shrink-0" />
-          <p className="text-xs text-destructive">{error}</p>
-        </div>
-      )}
-
-      {/* Main layout */}
-      <div
-        className="flex-1 p-3 grid grid-cols-[minmax(360px,2fr)_3fr] gap-3"
-        style={{ height: "calc(100vh - 57px)" }}
-      >
-        {/* Left: Chat */}
-        <div className="flex flex-col overflow-hidden rounded-xl border border-border/50 bg-card">
-          <div className="flex-1 flex flex-col p-4">
-            <ChatPanel
-              onSubmit={handleSubmit}
-              answer={answer}
-              seedNodes={seedNodes}
-              isLoading={isLoading}
-              latencyMs={latencyMs ?? undefined}
-              metadata={metadata}
-              exampleQuestions={EXAMPLE_QUESTIONS}
-            />
-          </div>
-        </div>
-
-        {/* Right: Graph + Cypher */}
-        <div className="flex flex-col gap-2 min-h-0">
-          <div className="relative flex-1 overflow-hidden rounded-xl border border-border/50 bg-[hsl(var(--graph-bg))]">
-            <GraphViewer
-              nodes={nodes}
-              edges={edges}
-              seedNodeIds={seedNodeIds}
-              onNodeSelect={handleNodeSelect}
-            />
-            {selectedNode && (
-              <NodeDetailPanel
-                node={selectedNode}
-                edges={edges}
-                allNodes={nodes}
-                isSeed={seedNodeIds.has(selectedNodeId!)}
-                onClose={() => setSelectedNodeId(null)}
-                onNodeSelect={(id) => setSelectedNodeId(id)}
-              />
-            )}
-          </div>
-          {cypher && (
-            <div className="rounded-xl border border-border/50 bg-card p-2">
-              <CypherPanel cypher={cypher} />
-            </div>
-          )}
-        </div>
-      </div>
+      <NavBar />
+      <Routes>
+        <Route path="/" element={<DashboardPage />} />
+        <Route path="/query" element={<QueryPage />} />
+        <Route path="/explore" element={<ExplorePage />} />
+        <Route path="/analytics" element={<AnalyticsPage />} />
+        <Route path="/evaluation" element={<EvaluationPage />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
     </div>
   );
 }

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,0 +1,69 @@
+import { NavLink } from "react-router-dom";
+import {
+  LayoutDashboard,
+  MessageSquare,
+  Globe,
+  BarChart3,
+  FlaskConical,
+  Network,
+} from "lucide-react";
+import { StatusBadges } from "@/components/StatusBadges";
+import { ThemeToggle } from "@/components/ThemeToggle";
+
+const NAV_ITEMS = [
+  { to: "/", label: "Dashboard", icon: LayoutDashboard },
+  { to: "/query", label: "Query", icon: MessageSquare },
+  { to: "/explore", label: "Explore", icon: Globe },
+  { to: "/analytics", label: "Analytics", icon: BarChart3 },
+  { to: "/evaluation", label: "Evaluation", icon: FlaskConical },
+] as const;
+
+export function NavBar() {
+  return (
+    <header className="relative z-10 border-b border-border/50 backdrop-blur-sm bg-background/80">
+      <div className="px-6 py-3 flex items-center gap-6">
+        {/* Logo */}
+        <div className="flex items-center gap-3 shrink-0">
+          <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-primary/10 border border-primary/20">
+            <Network size={18} className="text-primary" />
+          </div>
+          <div className="flex flex-col">
+            <h1 className="text-sm font-semibold tracking-tight text-foreground">
+              graphrag-neo4j
+            </h1>
+            <p className="text-[11px] text-muted-foreground leading-none">
+              Graph RAG over ML Research Papers
+            </p>
+          </div>
+        </div>
+
+        {/* Nav links */}
+        <nav className="flex items-center gap-1">
+          {NAV_ITEMS.map(({ to, label, icon: Icon }) => (
+            <NavLink
+              key={to}
+              to={to}
+              end={to === "/"}
+              className={({ isActive }) =>
+                `flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                  isActive
+                    ? "text-foreground bg-accent"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                }`
+              }
+            >
+              <Icon size={14} />
+              {label}
+            </NavLink>
+          ))}
+        </nav>
+
+        {/* Right side */}
+        <div className="ml-auto flex items-center gap-2">
+          <StatusBadges />
+          <ThemeToggle />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/QuickActions.tsx
+++ b/frontend/src/components/QuickActions.tsx
@@ -1,0 +1,33 @@
+import { Link } from "react-router-dom";
+import { MessageSquare, Globe, BarChart3, FlaskConical } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+const ACTIONS = [
+  { to: "/query", label: "Ask a Question", icon: MessageSquare, description: "Query the knowledge graph with natural language" },
+  { to: "/explore", label: "Explore Graph", icon: Globe, description: "Browse nodes and relationships" },
+  { to: "/analytics", label: "View Analytics", icon: BarChart3, description: "Communities, trends, and centrality" },
+  { to: "/evaluation", label: "Run Evaluation", icon: FlaskConical, description: "Test pipeline accuracy and metrics" },
+] as const;
+
+export function QuickActions() {
+  return (
+    <div className="grid grid-cols-4 gap-3">
+      {ACTIONS.map(({ to, label, icon: Icon, description }) => (
+        <Link key={to} to={to}>
+          <Button
+            variant="outline"
+            className="w-full h-auto flex flex-col items-start gap-1 p-4 border-border/50"
+          >
+            <div className="flex items-center gap-2">
+              <Icon size={14} className="text-primary" />
+              <span className="text-sm font-medium">{label}</span>
+            </div>
+            <span className="text-[11px] text-muted-foreground text-left font-normal">
+              {description}
+            </span>
+          </Button>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/SchemaViewer.tsx
+++ b/frontend/src/components/SchemaViewer.tsx
@@ -1,0 +1,70 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { GitBranch, Tag } from "lucide-react";
+import type { SchemaResponse } from "@/types/api";
+
+const LABEL_COLORS: Record<string, string> = {
+  Paper: "bg-blue-500",
+  Method: "bg-emerald-500",
+  Task: "bg-purple-500",
+  Dataset: "bg-orange-500",
+  Author: "bg-pink-500",
+};
+
+interface SchemaViewerProps {
+  schema: SchemaResponse | null;
+}
+
+export function SchemaViewer({ schema }: SchemaViewerProps) {
+  return (
+    <Card className="border-border/50">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm font-medium flex items-center gap-2">
+          <Tag size={14} className="text-muted-foreground" />
+          Graph Schema
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {!schema ? (
+          <p className="text-xs text-muted-foreground">Loading...</p>
+        ) : (
+          <>
+            <div>
+              <p className="text-xs font-medium text-muted-foreground mb-2">
+                Node Labels
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {schema.node_labels.map((label) => (
+                  <span
+                    key={label}
+                    className="flex items-center gap-1.5 text-xs text-foreground"
+                  >
+                    <span
+                      className={`w-2.5 h-2.5 rounded-full ${LABEL_COLORS[label] ?? "bg-gray-500"}`}
+                    />
+                    {label}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div>
+              <p className="text-xs font-medium text-muted-foreground mb-2">
+                Relationships
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {schema.relationship_types.map((rel) => (
+                  <span
+                    key={rel}
+                    className="flex items-center gap-1.5 text-xs text-foreground"
+                  >
+                    <GitBranch size={12} className="text-muted-foreground" />
+                    {rel}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/StatsCards.tsx
+++ b/frontend/src/components/StatsCards.tsx
@@ -1,0 +1,56 @@
+import { FileText, Cpu, Target, Database } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import type { GraphStats } from "@/types/api";
+
+const STAT_ITEMS = [
+  { key: "Paper", label: "Papers", icon: FileText, color: "blue" },
+  { key: "Method", label: "Methods", icon: Cpu, color: "emerald" },
+  { key: "Task", label: "Tasks", icon: Target, color: "purple" },
+  { key: "Dataset", label: "Datasets", icon: Database, color: "orange" },
+] as const;
+
+const COLOR_MAP: Record<string, string> = {
+  blue: "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20",
+  emerald: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20",
+  purple: "bg-purple-500/10 text-purple-600 dark:text-purple-400 border-purple-500/20",
+  orange: "bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/20",
+};
+
+interface StatsCardsProps {
+  stats: GraphStats | null;
+}
+
+export function StatsCards({ stats }: StatsCardsProps) {
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-4 gap-3">
+        {STAT_ITEMS.map(({ key, label, icon: Icon, color }) => (
+          <Card key={key} className="border-border/50">
+            <CardContent className="p-4">
+              <div className="flex items-center gap-3">
+                <div
+                  className={`flex items-center justify-center w-9 h-9 rounded-lg border ${COLOR_MAP[color]}`}
+                >
+                  <Icon size={16} />
+                </div>
+                <div>
+                  <p className="text-2xl font-semibold text-foreground tabular-nums">
+                    {stats ? (stats.node_counts[key] ?? 0).toLocaleString() : "---"}
+                  </p>
+                  <p className="text-xs text-muted-foreground">{label}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      {stats && (
+        <p className="text-xs text-muted-foreground text-center">
+          {stats.total_nodes.toLocaleString()} total nodes
+          {" · "}
+          {stats.total_edges.toLocaleString()} total relationships
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/SystemHealth.tsx
+++ b/frontend/src/components/SystemHealth.tsx
@@ -1,0 +1,69 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Activity } from "lucide-react";
+import type { HealthResponse } from "@/types/api";
+
+interface SystemHealthProps {
+  health: HealthResponse | null;
+}
+
+function formatUptime(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+export function SystemHealth({ health }: SystemHealthProps) {
+  return (
+    <Card className="border-border/50">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm font-medium flex items-center gap-2">
+          <Activity size={14} className="text-muted-foreground" />
+          System Health
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {!health ? (
+          <p className="text-xs text-muted-foreground">Loading...</p>
+        ) : (
+          <>
+            {health.components.map((comp) => (
+              <div
+                key={comp.name}
+                className="flex items-center justify-between"
+              >
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`w-2 h-2 rounded-full ${
+                      comp.status === "healthy"
+                        ? "bg-emerald-500"
+                        : "bg-red-500"
+                    }`}
+                  />
+                  <span className="text-xs text-foreground">{comp.name}</span>
+                </div>
+                <span className="text-xs text-muted-foreground">
+                  {comp.response_time_ms != null
+                    ? `${comp.response_time_ms}ms`
+                    : comp.status}
+                </span>
+              </div>
+            ))}
+            <div className="pt-2 border-t border-border/50 flex items-center justify-between">
+              <span className="text-xs text-muted-foreground">Version</span>
+              <span className="text-xs text-foreground font-mono">
+                {health.version}
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-muted-foreground">Uptime</span>
+              <span className="text-xs text-foreground">
+                {formatUptime(health.uptime_seconds)}
+              </span>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/ui/separator.tsx
+++ b/frontend/src/components/ui/separator.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,80 @@
+/**
+ * lib/api.ts
+ *
+ * API client for graphrag-neo4j backend.
+ * All fetch calls go through this module.
+ */
+
+import type {
+  ExploreResponse,
+  GraphStats,
+  HealthResponse,
+  Neo4jPingResponse,
+  PingResponse,
+  QueryResponse,
+  SchemaResponse,
+} from "@/types/api";
+import { ApiError } from "@/types/api";
+
+const BASE_URL = import.meta.env.VITE_API_URL ?? "";
+const API_KEY = import.meta.env.VITE_API_KEY ?? "";
+
+async function apiFetch<T>(
+  path: string,
+  options: RequestInit = {},
+): Promise<T> {
+  const url = `${BASE_URL}${path}`;
+
+  const response = await fetch(url, {
+    headers: {
+      "Content-Type": "application/json",
+      ...(API_KEY ? { "X-API-Key": API_KEY } : {}),
+      ...options.headers,
+    },
+    ...options,
+  });
+
+  if (!response.ok) {
+    let detail = `HTTP ${response.status}`;
+    try {
+      const body = await response.json();
+      detail = body.detail ?? detail;
+    } catch {
+      detail = response.statusText || detail;
+    }
+    throw new ApiError(response.status, detail);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export async function queryGraph(question: string): Promise<QueryResponse> {
+  return apiFetch<QueryResponse>("/api/v1/rag/query", {
+    method: "POST",
+    body: JSON.stringify({ question }),
+  });
+}
+
+export async function fetchSchema(): Promise<SchemaResponse> {
+  return apiFetch<SchemaResponse>("/api/v1/graph/schema");
+}
+
+export async function exploreGraph(limit = 50): Promise<ExploreResponse> {
+  return apiFetch<ExploreResponse>(`/api/v1/graph/explore?limit=${limit}`);
+}
+
+export async function pingBackend(): Promise<PingResponse> {
+  return apiFetch<PingResponse>("/api/v1/health/ping");
+}
+
+export async function pingNeo4j(): Promise<Neo4jPingResponse> {
+  return apiFetch<Neo4jPingResponse>("/api/v1/health/neo4j");
+}
+
+export async function checkHealth(): Promise<HealthResponse> {
+  return apiFetch<HealthResponse>("/api/v1/health/status");
+}
+
+export async function fetchGraphStats(): Promise<GraphStats> {
+  return apiFetch<GraphStats>("/api/v1/graph/stats");
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -1,0 +1,15 @@
+import { BarChart3 } from "lucide-react";
+
+export default function AnalyticsPage() {
+  return (
+    <div className="flex-1 flex items-center justify-center">
+      <div className="text-center space-y-3">
+        <BarChart3 size={48} className="mx-auto text-muted-foreground/40" />
+        <h2 className="text-lg font-semibold text-foreground">Graph Analytics</h2>
+        <p className="text-sm text-muted-foreground">
+          Communities, trends, and centrality rankings. Coming in Phase D.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,49 @@
+import { useState, useEffect } from "react";
+import { StatsCards } from "@/components/StatsCards";
+import { SchemaViewer } from "@/components/SchemaViewer";
+import { SystemHealth } from "@/components/SystemHealth";
+import { QuickActions } from "@/components/QuickActions";
+import { Separator } from "@/components/ui/separator";
+import { fetchGraphStats, fetchSchema, checkHealth } from "@/lib/api";
+import type { GraphStats, SchemaResponse, HealthResponse } from "@/types/api";
+
+export default function DashboardPage() {
+  const [stats, setStats] = useState<GraphStats | null>(null);
+  const [schema, setSchema] = useState<SchemaResponse | null>(null);
+  const [health, setHealth] = useState<HealthResponse | null>(null);
+
+  useEffect(() => {
+    fetchGraphStats().then(setStats).catch(() => setStats(null));
+    fetchSchema().then(setSchema).catch(() => setSchema(null));
+    checkHealth().then(setHealth).catch(() => setHealth(null));
+  }, []);
+
+  return (
+    <div className="flex-1 overflow-auto p-6 space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-foreground">
+          Knowledge Graph Overview
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          System status and graph statistics at a glance
+        </p>
+      </div>
+
+      <StatsCards stats={stats} />
+
+      <Separator className="opacity-50" />
+
+      <div className="grid grid-cols-2 gap-4">
+        <SchemaViewer schema={schema} />
+        <SystemHealth health={health} />
+      </div>
+
+      <Separator className="opacity-50" />
+
+      <div>
+        <p className="text-sm font-medium text-foreground mb-3">Quick Actions</p>
+        <QuickActions />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/EvaluationPage.tsx
+++ b/frontend/src/pages/EvaluationPage.tsx
@@ -1,0 +1,15 @@
+import { FlaskConical } from "lucide-react";
+
+export default function EvaluationPage() {
+  return (
+    <div className="flex-1 flex items-center justify-center">
+      <div className="text-center space-y-3">
+        <FlaskConical size={48} className="mx-auto text-muted-foreground/40" />
+        <h2 className="text-lg font-semibold text-foreground">Evaluation Dashboard</h2>
+        <p className="text-sm text-muted-foreground">
+          Test pipeline accuracy, metrics, and baselines. Coming in Phase E.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ExplorePage.tsx
+++ b/frontend/src/pages/ExplorePage.tsx
@@ -1,0 +1,15 @@
+import { Globe } from "lucide-react";
+
+export default function ExplorePage() {
+  return (
+    <div className="flex-1 flex items-center justify-center">
+      <div className="text-center space-y-3">
+        <Globe size={48} className="mx-auto text-muted-foreground/40" />
+        <h2 className="text-lg font-semibold text-foreground">Graph Explorer</h2>
+        <p className="text-sm text-muted-foreground">
+          Browse and search the knowledge graph. Coming in Phase B.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/QueryPage.tsx
+++ b/frontend/src/pages/QueryPage.tsx
@@ -1,0 +1,128 @@
+import { useState, useCallback } from "react";
+import { ChatPanel } from "@/components/ChatPanel";
+import { GraphViewer } from "@/components/GraphViewer";
+import { CypherPanel } from "@/components/CypherPanel";
+import { NodeDetailPanel } from "@/components/NodeDetailPanel";
+import { queryGraph } from "@/lib/api";
+import { ApiError } from "@/types/api";
+import type { SeedNode, GraphNode, GraphEdge, PipelineMetadata } from "@/types/api";
+import { AlertCircle } from "lucide-react";
+
+const EXAMPLE_QUESTIONS = [
+  "What methods are used for object detection?",
+  "Which papers introduced transformer architectures?",
+  "What datasets are used to benchmark image classification?",
+  "How does BERT relate to other NLP methods?",
+];
+
+export default function QueryPage() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [answer, setAnswer] = useState("");
+  const [seedNodes, setSeedNodes] = useState<SeedNode[]>([]);
+  const [nodes, setNodes] = useState<GraphNode[]>([]);
+  const [edges, setEdges] = useState<GraphEdge[]>([]);
+  const [cypher, setCypher] = useState("");
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
+  const [metadata, setMetadata] = useState<PipelineMetadata | null>(null);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+  const handleSubmit = async (question: string) => {
+    setIsLoading(true);
+    setError(null);
+    setAnswer("");
+    setSeedNodes([]);
+    setNodes([]);
+    setEdges([]);
+    setCypher("");
+    setLatencyMs(null);
+    setMetadata(null);
+    setSelectedNodeId(null);
+
+    try {
+      const response = await queryGraph(question);
+      setAnswer(response.answer);
+      setSeedNodes(response.seed_nodes);
+      setNodes(response.nodes);
+      setEdges(response.edges);
+      setCypher(response.cypher_used);
+      setLatencyMs(response.latency_ms);
+      setMetadata(response.metadata);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(`API error (${err.statusCode}): ${err.detail}`);
+      } else {
+        setError("Network error. Is the backend running?");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const seedNodeIds = new Set(seedNodes.map((sn) => sn.id));
+
+  const handleNodeSelect = useCallback((nodeId: string | null) => {
+    setSelectedNodeId(nodeId);
+  }, []);
+
+  const selectedNode = selectedNodeId
+    ? nodes.find((n) => (n.uid || n.id) === selectedNodeId) ?? null
+    : null;
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      {/* Error banner */}
+      {error && (
+        <div className="mx-4 mt-3 p-3 rounded-lg bg-destructive/10 border border-destructive/20 flex items-start gap-2">
+          <AlertCircle size={14} className="text-destructive mt-0.5 shrink-0" />
+          <p className="text-xs text-destructive">{error}</p>
+        </div>
+      )}
+
+      {/* Main layout */}
+      <div className="flex-1 p-3 grid grid-cols-[minmax(360px,2fr)_3fr] gap-3 min-h-0">
+        {/* Left: Chat */}
+        <div className="flex flex-col overflow-hidden rounded-xl border border-border/50 bg-card">
+          <div className="flex-1 flex flex-col p-4">
+            <ChatPanel
+              onSubmit={handleSubmit}
+              answer={answer}
+              seedNodes={seedNodes}
+              isLoading={isLoading}
+              latencyMs={latencyMs ?? undefined}
+              metadata={metadata}
+              exampleQuestions={EXAMPLE_QUESTIONS}
+            />
+          </div>
+        </div>
+
+        {/* Right: Graph + Cypher */}
+        <div className="flex flex-col gap-2 min-h-0">
+          <div className="relative flex-1 overflow-hidden rounded-xl border border-border/50 bg-[hsl(var(--graph-bg))]">
+            <GraphViewer
+              nodes={nodes}
+              edges={edges}
+              seedNodeIds={seedNodeIds}
+              onNodeSelect={handleNodeSelect}
+            />
+            {selectedNode && (
+              <NodeDetailPanel
+                node={selectedNode}
+                edges={edges}
+                allNodes={nodes}
+                isSeed={seedNodeIds.has(selectedNodeId!)}
+                onClose={() => setSelectedNodeId(null)}
+                onNodeSelect={(id) => setSelectedNodeId(id)}
+              />
+            )}
+          </div>
+          {cypher && (
+            <div className="rounded-xl border border-border/50 bg-card p-2">
+              <CypherPanel cypher={cypher} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -130,6 +130,15 @@ export interface HealthResponse {
   uptime_seconds: number;
 }
 
+// /api/v1/graph/stats
+
+export interface GraphStats {
+  total_nodes: number;
+  total_edges: number;
+  node_counts: Record<string, number>;
+  edge_counts: Record<string, number>;
+}
+
 // Client-side error type
 
 export class ApiError extends Error {


### PR DESCRIPTION
## Summary
- Add React Router with 5 routes: `/` (Dashboard), `/query`, `/explore`, `/analytics`, `/evaluation`
- Create persistent NavBar with page links, StatusBadges, and ThemeToggle
- Create Dashboard page with live StatsCards, SchemaViewer, SystemHealth, and QuickActions
- Extract QueryPage from App.tsx preserving all existing query UI behavior
- Add stub pages for Explore, Analytics, Evaluation (future phases B/D/E)
- Add `fetchGraphStats()` API call and `GraphStats` type

## New Files (11)
- `components/NavBar.tsx` — Navigation bar with active page highlighting
- `components/StatsCards.tsx` — 4 color-coded metric cards (Paper, Method, Task, Dataset)
- `components/SchemaViewer.tsx` — Node labels + relationship types display
- `components/SystemHealth.tsx` — Component health, version, uptime
- `components/QuickActions.tsx` — Quick navigation buttons to other pages
- `pages/DashboardPage.tsx` — Stats + schema + health + quick actions
- `pages/QueryPage.tsx` — Extracted from App.tsx (identical behavior)
- `pages/ExplorePage.tsx` — Stub placeholder
- `pages/AnalyticsPage.tsx` — Stub placeholder
- `pages/EvaluationPage.tsx` — Stub placeholder
- `components/ui/separator.tsx` — shadcn/ui separator

## Test plan
- [ ] Dashboard (`/`) loads with live stats, schema, and health data
- [ ] Query page (`/query`) works identically to old single-page app
- [ ] NavBar highlights active page correctly
- [ ] Stub pages render at `/explore`, `/analytics`, `/evaluation`
- [ ] Theme toggle works across all pages
- [ ] Status badges poll correctly on all pages
- [ ] Browser back/forward and direct URL navigation work
- [ ] Build succeeds (`vite build` passes)

Closes #19