### PR TITLE
fix(test): update mocks for Author model and undirected traversal #25

### DIFF
--- a/backend/tests/unit/modules/graph/test_handler.py
+++ b/backend/tests/unit/modules/graph/test_handler.py
@@ -54,6 +54,7 @@ class TestGraphExploreEndpoint:
 class TestGraphStatsEndpoint:
     def test_success(self, client, auth_headers, mock_neo4j_client):
         mock_neo4j_client.run_query.side_effect = [
+            [{"c": 5}],   # Author
             [{"c": 10}], [{"c": 20}], [{"c": 30}], [{"c": 40}],
             [{"t": "USED_FOR"}],
             [{"c": 5}],
@@ -61,7 +62,7 @@ class TestGraphStatsEndpoint:
         resp = client.get("/api/v1/graph/stats", headers=auth_headers)
         assert resp.status_code == 200
         data = resp.json()
-        assert data["total_nodes"] == 100
+        assert data["total_nodes"] == 105
         assert "node_counts" in data
 
 

--- a/backend/tests/unit/modules/graph/test_repositories.py
+++ b/backend/tests/unit/modules/graph/test_repositories.py
@@ -137,6 +137,7 @@ class TestGraphExploreRepository:
 
     def test_get_stats(self, mock_neo4j_client):
         mock_neo4j_client.run_query.side_effect = [
+            [{"c": 5}],   # Author
             [{"c": 10}],  # Paper
             [{"c": 20}],  # Method
             [{"c": 30}],  # Task
@@ -147,7 +148,7 @@ class TestGraphExploreRepository:
         ]
         repo = GraphExploreRepository(mock_neo4j_client)
         stats = repo.get_stats()
-        assert stats["total_nodes"] == 100
+        assert stats["total_nodes"] == 105
         assert stats["total_edges"] == 8
         assert stats["node_counts"]["Paper"] == 10
         assert stats["edge_counts"]["USED_FOR"] == 5

--- a/backend/tests/unit/modules/rag/test_repositories.py
+++ b/backend/tests/unit/modules/rag/test_repositories.py
@@ -82,7 +82,8 @@ class TestTraversalRepository:
         mock_neo4j_client.run_query.return_value = [
             {
                 "seed": seed,
-                "nodes1": [n1],
+                "seed_label": "Paper",
+                "nodes1": [{"node": n1, "label": "Task"}],
                 "nodes2": [],
                 "e1": [{"from": "p1", "to": "t1", "type": "USED_FOR", "props": {}}],
                 "e2": [],


### PR DESCRIPTION
## Summary
- Add missing Author entry to `get_stats` mock side_effects (ALL_MODELS now has 5 models: Author, Paper, Method, Task, Dataset)
- Update `total_nodes` assertions from 100 to 105 to account for Author
- Fix `test_traverse_with_data` mock to wrap neighbor nodes in `{"node": n1, "label": "Task"}` dicts (FakeNode extends dict, so `isinstance(wrapped, dict)` was True, causing `wrapped.get("node")` to return None)
- Add `seed_label` field to traversal mock data

## Test plan
- [x] All 3 previously failing tests now pass
- [x] Full unit test suite: 407 passed, 0 failed