### PR TITLE
feat(frontend): Query page pipeline transparency #21

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@neo4j-nvl/react": "^1.1.0",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-progress": "^1.1.8",
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slider": "^1.3.6",
@@ -1645,6 +1646,68 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-progress/-/react-progress-1.1.8.tgz",
+      "integrity": "sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+      "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@neo4j-nvl/react": "^1.1.0",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slider": "^1.3.6",

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -3,6 +3,10 @@ import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Send, Loader2, Sparkles, Brain, GitBranch, FileText, Zap, ChevronDown, ChevronRight } from "lucide-react";
 import type { SeedNode, PipelineMetadata } from "@/types/api";
+import { QueryTypeBadge } from "@/components/QueryTypeBadge";
+import { RetrievalStrategyBadge } from "@/components/RetrievalStrategyBadge";
+import { ProvenanceBadge } from "@/components/ProvenanceBadge";
+import { UnsupportedClaimsPanel } from "@/components/UnsupportedClaimsPanel";
 
 const BADGE_COLORS: Record<string, string> = {
   Paper: "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20",
@@ -98,9 +102,27 @@ export function ChatPanel({
       {answer && (
         <ScrollArea className="flex-1 rounded-lg border border-border/40 bg-secondary/30">
           <div className="p-4 space-y-3">
+            {/* Query type + retrieval strategy badges */}
+            {metadata && (metadata.query_type || metadata.retrieval_strategy) && (
+              <div className="flex items-center gap-2 flex-wrap">
+                <QueryTypeBadge queryType={metadata.query_type} />
+                <RetrievalStrategyBadge strategy={metadata.retrieval_strategy} />
+              </div>
+            )}
+
             <p className="text-[13px] leading-relaxed whitespace-pre-wrap text-foreground/90">
               {answer}
             </p>
+
+            {/* Provenance score */}
+            {metadata?.provenance_score !== undefined && metadata?.provenance_score !== null && (
+              <ProvenanceBadge score={metadata.provenance_score} />
+            )}
+
+            {/* Unsupported claims warning */}
+            {metadata?.unsupported_claims && metadata.unsupported_claims.length > 0 && (
+              <UnsupportedClaimsPanel claims={metadata.unsupported_claims} />
+            )}
 
             {/* Pipeline Metadata */}
             {(latencyMs !== undefined || metadata) && (

--- a/frontend/src/components/ProvenanceBadge.tsx
+++ b/frontend/src/components/ProvenanceBadge.tsx
@@ -1,0 +1,35 @@
+import { Progress } from "@/components/ui/progress";
+import { ShieldCheck } from "lucide-react";
+
+interface ProvenanceBadgeProps {
+  score: number | null;
+}
+
+function getColor(score: number): string {
+  if (score >= 0.8) return "text-emerald-500";
+  if (score >= 0.5) return "text-amber-500";
+  return "text-red-500";
+}
+
+function getBarClass(score: number): string {
+  if (score >= 0.8) return "[&>div]:bg-emerald-500";
+  if (score >= 0.5) return "[&>div]:bg-amber-500";
+  return "[&>div]:bg-red-500";
+}
+
+export function ProvenanceBadge({ score }: ProvenanceBadgeProps) {
+  if (score === null || score === undefined) return null;
+
+  const pct = Math.round(score * 100);
+
+  return (
+    <div className="flex items-center gap-2">
+      <ShieldCheck size={12} className={`shrink-0 ${getColor(score)}`} />
+      <span className="text-[11px] text-muted-foreground shrink-0">Provenance</span>
+      <Progress value={pct} className={`h-1.5 flex-1 ${getBarClass(score)}`} />
+      <span className={`text-[11px] font-medium tabular-nums ${getColor(score)}`}>
+        {pct}%
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/QueryTypeBadge.tsx
+++ b/frontend/src/components/QueryTypeBadge.tsx
@@ -1,0 +1,51 @@
+import { Badge } from "@/components/ui/badge";
+
+const QUERY_TYPE_CONFIG: Record<string, { label: string; className: string }> = {
+  FACTUAL_LOOKUP: {
+    label: "Factual",
+    className: "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20",
+  },
+  COMPARISON: {
+    label: "Comparison",
+    className: "bg-violet-500/10 text-violet-600 dark:text-violet-400 border-violet-500/20",
+  },
+  TEMPORAL: {
+    label: "Temporal",
+    className: "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20",
+  },
+  NETWORK: {
+    label: "Network",
+    className: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20",
+  },
+  EXPLORATORY: {
+    label: "Exploratory",
+    className: "bg-cyan-500/10 text-cyan-600 dark:text-cyan-400 border-cyan-500/20",
+  },
+  AGGREGATION: {
+    label: "Aggregation",
+    className: "bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/20",
+  },
+  MULTI_HOP: {
+    label: "Multi-Hop",
+    className: "bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 border-indigo-500/20",
+  },
+};
+
+interface QueryTypeBadgeProps {
+  queryType: string;
+}
+
+export function QueryTypeBadge({ queryType }: QueryTypeBadgeProps) {
+  if (!queryType) return null;
+
+  const config = QUERY_TYPE_CONFIG[queryType] ?? {
+    label: queryType.replace(/_/g, " "),
+    className: "bg-muted text-muted-foreground border-border",
+  };
+
+  return (
+    <Badge variant="outline" className={`text-[10px] font-medium py-0 ${config.className}`}>
+      {config.label}
+    </Badge>
+  );
+}

--- a/frontend/src/components/RetrievalStrategyBadge.tsx
+++ b/frontend/src/components/RetrievalStrategyBadge.tsx
@@ -1,0 +1,29 @@
+import { Database, Search, GitMerge, ArrowRight } from "lucide-react";
+
+const STRATEGY_CONFIG: Record<string, { label: string; Icon: typeof Database }> = {
+  GRAPH_ONLY: { label: "Graph Only", Icon: Database },
+  VECTOR_ONLY: { label: "Vector Only", Icon: Search },
+  HYBRID_PARALLEL: { label: "Hybrid Parallel", Icon: GitMerge },
+  HYBRID_SEQUENTIAL: { label: "Hybrid Sequential", Icon: ArrowRight },
+};
+
+interface RetrievalStrategyBadgeProps {
+  strategy: string;
+}
+
+export function RetrievalStrategyBadge({ strategy }: RetrievalStrategyBadgeProps) {
+  if (!strategy) return null;
+
+  const config = STRATEGY_CONFIG[strategy] ?? {
+    label: strategy.replace(/_/g, " "),
+    Icon: Search,
+  };
+  const { label, Icon } = config;
+
+  return (
+    <div className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground">
+      <Icon size={11} className="shrink-0" />
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/UnsupportedClaimsPanel.tsx
+++ b/frontend/src/components/UnsupportedClaimsPanel.tsx
@@ -1,0 +1,25 @@
+import { AlertTriangle } from "lucide-react";
+
+interface UnsupportedClaimsPanelProps {
+  claims: string[];
+}
+
+export function UnsupportedClaimsPanel({ claims }: UnsupportedClaimsPanelProps) {
+  if (!claims || claims.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-2.5 space-y-1.5">
+      <div className="flex items-center gap-1.5 text-[11px] font-medium text-amber-600 dark:text-amber-400">
+        <AlertTriangle size={12} className="shrink-0" />
+        <span>Unsupported Claims ({claims.length})</span>
+      </div>
+      <ul className="space-y-1 pl-5">
+        {claims.map((claim, i) => (
+          <li key={i} className="text-[11px] text-amber-700/80 dark:text-amber-300/70 list-disc">
+            {claim}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/progress.tsx
+++ b/frontend/src/components/ui/progress.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -43,6 +43,21 @@ export interface GraphEdge {
 
 // Pipeline metadata for evaluation
 
+export type QueryType =
+  | "FACTUAL_LOOKUP"
+  | "COMPARISON"
+  | "TEMPORAL"
+  | "NETWORK"
+  | "EXPLORATORY"
+  | "AGGREGATION"
+  | "MULTI_HOP";
+
+export type RetrievalStrategy =
+  | "GRAPH_ONLY"
+  | "VECTOR_ONLY"
+  | "HYBRID_PARALLEL"
+  | "HYBRID_SEQUENTIAL";
+
 export interface PipelineMetadata {
   llm_provider: string;
   llm_model: string;
@@ -56,6 +71,10 @@ export interface PipelineMetadata {
   edge_count: number;
   context_length: number;
   step_timings: Record<string, number>;
+  query_type: string;
+  retrieval_strategy: string;
+  provenance_score: number | null;
+  unsupported_claims: string[];
 }
 
 // Main response


### PR DESCRIPTION
## Summary
- Add query_type, retrieval_strategy, provenance_score, unsupported_claims to PipelineMetadata type
- Create QueryTypeBadge, RetrievalStrategyBadge, ProvenanceBadge, UnsupportedClaimsPanel components
- Install shadcn/ui progress component
- Integrate into ChatPanel answer section

## Test plan
- [x] TypeScript compiles
- [x] Production build passes
- [ ] Visual QA with live backend