### PR TITLE
feat(frontend): Analytics page — communities, trends, centrality #22

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1804,6 +1805,36 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/frontend/src/components/CentralityTable.tsx
+++ b/frontend/src/components/CentralityTable.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ArrowUpDown } from "lucide-react";
+import type { CommunityMember } from "@/types/api";
+
+interface CentralityTableProps {
+  members: CommunityMember[];
+}
+
+type SortKey = "name" | "pagerank";
+
+export function CentralityTable({ members }: CentralityTableProps) {
+  const [sortKey, setSortKey] = useState<SortKey>("pagerank");
+  const [sortAsc, setSortAsc] = useState(false);
+
+  if (members.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+        <p className="text-sm">No centrality data available.</p>
+        <p className="text-xs mt-1">Run analytics to compute PageRank.</p>
+      </div>
+    );
+  }
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortAsc((v) => !v);
+    } else {
+      setSortKey(key);
+      setSortAsc(key === "name");
+    }
+  };
+
+  const sorted = [...members].sort((a, b) => {
+    const dir = sortAsc ? 1 : -1;
+    if (sortKey === "name") {
+      return dir * a.name.localeCompare(b.name);
+    }
+    return dir * ((a.pagerank ?? 0) - (b.pagerank ?? 0));
+  });
+
+  return (
+    <div className="rounded-lg border border-border/50 overflow-hidden">
+      <Table>
+        <TableHeader>
+          <TableRow className="bg-secondary/30">
+            <TableHead className="w-12 text-center text-[11px]">#</TableHead>
+            <TableHead>
+              <button
+                onClick={() => handleSort("name")}
+                className="flex items-center gap-1 text-[11px] hover:text-foreground transition-colors"
+              >
+                Name
+                <ArrowUpDown size={10} />
+              </button>
+            </TableHead>
+            <TableHead className="text-right">
+              <button
+                onClick={() => handleSort("pagerank")}
+                className="flex items-center gap-1 ml-auto text-[11px] hover:text-foreground transition-colors"
+              >
+                PageRank
+                <ArrowUpDown size={10} />
+              </button>
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sorted.map((m, i) => (
+            <TableRow key={m.uid}>
+              <TableCell className="text-center text-xs text-muted-foreground tabular-nums">
+                {i + 1}
+              </TableCell>
+              <TableCell className="text-xs font-medium truncate max-w-[200px]">
+                {m.name}
+              </TableCell>
+              <TableCell className="text-right text-xs tabular-nums text-muted-foreground">
+                {m.pagerank !== undefined ? m.pagerank.toFixed(6) : "—"}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/frontend/src/components/CommunityList.tsx
+++ b/frontend/src/components/CommunityList.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import { ChevronDown, ChevronRight, Users } from "lucide-react";
+import type { Community } from "@/types/api";
+
+interface CommunityListProps {
+  communities: Community[];
+  totalCommunities: number;
+}
+
+export function CommunityList({ communities, totalCommunities }: CommunityListProps) {
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+
+  if (communities.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+        <Users size={32} className="mb-2 opacity-40" />
+        <p className="text-sm">No communities detected yet.</p>
+        <p className="text-xs mt-1">Run analytics to detect communities.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-muted-foreground">
+        {totalCommunities} communities detected
+      </p>
+      <div className="space-y-1.5">
+        {communities.map((c) => {
+          const isExpanded = expandedId === c.community_id;
+          return (
+            <div
+              key={c.community_id}
+              className="rounded-lg border border-border/50 bg-card overflow-hidden"
+            >
+              <button
+                onClick={() => setExpandedId(isExpanded ? null : c.community_id)}
+                className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-secondary/50 transition-colors"
+              >
+                {isExpanded ? (
+                  <ChevronDown size={14} className="text-muted-foreground shrink-0" />
+                ) : (
+                  <ChevronRight size={14} className="text-muted-foreground shrink-0" />
+                )}
+                <span className="text-sm font-medium">Community {c.community_id}</span>
+                <span className="ml-auto text-xs text-muted-foreground tabular-nums">
+                  {c.member_count} members
+                </span>
+              </button>
+              {isExpanded && c.top_members.length > 0 && (
+                <div className="px-3 pb-2 pt-0">
+                  <div className="border-t border-border/30 pt-2 space-y-1">
+                    {c.top_members.map((m) => (
+                      <div
+                        key={m.uid}
+                        className="flex items-center justify-between text-xs px-2 py-1 rounded bg-secondary/30"
+                      >
+                        <span className="text-foreground/80 truncate">{m.name}</span>
+                        {m.pagerank !== undefined && (
+                          <span className="text-muted-foreground tabular-nums shrink-0 ml-2">
+                            PR: {m.pagerank.toFixed(4)}
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TrendingChart.tsx
+++ b/frontend/src/components/TrendingChart.tsx
@@ -1,0 +1,50 @@
+import type { TrendingItem } from "@/types/api";
+import { TrendingUp } from "lucide-react";
+
+interface TrendingChartProps {
+  title: string;
+  items: TrendingItem[];
+  color: string;
+}
+
+export function TrendingChart({ title, items, color }: TrendingChartProps) {
+  if (items.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
+        <TrendingUp size={24} className="mb-2 opacity-40" />
+        <p className="text-xs">No {title.toLowerCase()} data yet.</p>
+      </div>
+    );
+  }
+
+  const maxScore = Math.max(...items.map((i) => i.trend_score));
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+        {title}
+      </h3>
+      <div className="space-y-1.5">
+        {items.map((item) => {
+          const pct = maxScore > 0 ? (item.trend_score / maxScore) * 100 : 0;
+          return (
+            <div key={item.uid} className="flex items-center gap-2">
+              <span className="text-xs text-foreground/80 w-36 truncate shrink-0" title={item.name}>
+                {item.name}
+              </span>
+              <div className="flex-1 h-5 rounded bg-secondary/50 overflow-hidden">
+                <div
+                  className="h-full rounded transition-all duration-300"
+                  style={{ width: `${Math.max(pct, 2)}%`, backgroundColor: color }}
+                />
+              </div>
+              <span className="text-[11px] text-muted-foreground tabular-nums w-12 text-right shrink-0">
+                {item.trend_score.toFixed(1)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -1,0 +1,120 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn(
+      "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,8 @@
  */
 
 import type {
+  AnalyticsRunResponse,
+  CommunitiesResponse,
   ExploreResponse,
   GraphStats,
   HealthResponse,
@@ -15,6 +17,7 @@ import type {
   QueryResponse,
   SchemaResponse,
   SearchResponse,
+  TrendsResponse,
 } from "@/types/api";
 import { ApiError } from "@/types/api";
 
@@ -93,4 +96,27 @@ export async function searchNodes(
 
 export async function fetchNodeDetail(uid: string): Promise<NodeDetail> {
   return apiFetch<NodeDetail>(`/api/v1/graph/nodes/${encodeURIComponent(uid)}`);
+}
+
+export async function runAnalytics(): Promise<AnalyticsRunResponse> {
+  return apiFetch<AnalyticsRunResponse>("/api/v1/analytics/run", {
+    method: "POST",
+  });
+}
+
+export async function fetchCommunities(
+  limit = 50,
+): Promise<CommunitiesResponse> {
+  return apiFetch<CommunitiesResponse>(
+    `/api/v1/analytics/communities?limit=${limit}`,
+  );
+}
+
+export async function fetchTrends(
+  type: "Method" | "Task" = "Method",
+  limit = 10,
+): Promise<TrendsResponse> {
+  return apiFetch<TrendsResponse>(
+    `/api/v1/analytics/trends?type=${type}&limit=${limit}`,
+  );
 }

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -1,14 +1,177 @@
-import { BarChart3 } from "lucide-react";
+import { useState, useEffect, useCallback } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { CommunityList } from "@/components/CommunityList";
+import { TrendingChart } from "@/components/TrendingChart";
+import { CentralityTable } from "@/components/CentralityTable";
+import { runAnalytics, fetchCommunities, fetchTrends } from "@/lib/api";
+import type {
+  Community,
+  CommunityMember,
+  TrendingItem,
+} from "@/types/api";
+import { Loader2, Play, BarChart3 } from "lucide-react";
 
 export default function AnalyticsPage() {
+  const [isRunning, setIsRunning] = useState(false);
+  const [runMessage, setRunMessage] = useState<string | null>(null);
+
+  const [communities, setCommunities] = useState<Community[]>([]);
+  const [totalCommunities, setTotalCommunities] = useState(0);
+  const [isLoadingCommunities, setIsLoadingCommunities] = useState(false);
+
+  const [methodTrends, setMethodTrends] = useState<TrendingItem[]>([]);
+  const [taskTrends, setTaskTrends] = useState<TrendingItem[]>([]);
+  const [isLoadingTrends, setIsLoadingTrends] = useState(false);
+
+  const [centralityMembers, setCentralityMembers] = useState<CommunityMember[]>([]);
+
+  const loadCommunities = useCallback(async () => {
+    setIsLoadingCommunities(true);
+    try {
+      const resp = await fetchCommunities(50);
+      setCommunities(resp.communities);
+      setTotalCommunities(resp.total_communities);
+
+      // Extract all members with pagerank for centrality tab
+      const allMembers: CommunityMember[] = [];
+      for (const c of resp.communities) {
+        for (const m of c.top_members) {
+          if (m.pagerank !== undefined) {
+            allMembers.push(m);
+          }
+        }
+      }
+      // Deduplicate by uid and sort by pagerank descending
+      const seen = new Set<string>();
+      const unique = allMembers.filter((m) => {
+        if (seen.has(m.uid)) return false;
+        seen.add(m.uid);
+        return true;
+      });
+      unique.sort((a, b) => (b.pagerank ?? 0) - (a.pagerank ?? 0));
+      setCentralityMembers(unique);
+    } catch {
+      // keep empty
+    } finally {
+      setIsLoadingCommunities(false);
+    }
+  }, []);
+
+  const loadTrends = useCallback(async () => {
+    setIsLoadingTrends(true);
+    try {
+      const [methods, tasks] = await Promise.all([
+        fetchTrends("Method", 10),
+        fetchTrends("Task", 10),
+      ]);
+      setMethodTrends(methods.items);
+      setTaskTrends(tasks.items);
+    } catch {
+      // keep empty
+    } finally {
+      setIsLoadingTrends(false);
+    }
+  }, []);
+
+  // Load data on mount
+  useEffect(() => {
+    loadCommunities();
+    loadTrends();
+  }, [loadCommunities, loadTrends]);
+
+  const handleRunAnalytics = async () => {
+    setIsRunning(true);
+    setRunMessage(null);
+    try {
+      const resp = await runAnalytics();
+      setRunMessage(resp.message);
+      // Reload data after analytics run
+      await Promise.all([loadCommunities(), loadTrends()]);
+    } catch {
+      setRunMessage("Failed to run analytics pipeline.");
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  const isLoading = isLoadingCommunities || isLoadingTrends;
+
   return (
-    <div className="flex-1 flex items-center justify-center">
-      <div className="text-center space-y-3">
-        <BarChart3 size={48} className="mx-auto text-muted-foreground/40" />
-        <h2 className="text-lg font-semibold text-foreground">Graph Analytics</h2>
-        <p className="text-sm text-muted-foreground">
-          Communities, trends, and centrality rankings. Coming in Phase D.
-        </p>
+    <div className="flex-1 flex flex-col min-h-0">
+      <div className="flex-1 p-3 flex flex-col gap-3 min-h-0 max-w-5xl mx-auto w-full">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <BarChart3 size={18} className="text-primary" />
+            <h1 className="text-lg font-semibold">Graph Analytics</h1>
+          </div>
+          <button
+            onClick={handleRunAnalytics}
+            disabled={isRunning}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-primary text-primary-foreground text-xs font-medium hover:bg-primary/90 disabled:opacity-50 transition-all"
+          >
+            {isRunning ? (
+              <Loader2 size={12} className="animate-spin" />
+            ) : (
+              <Play size={12} />
+            )}
+            {isRunning ? "Running..." : "Run Analytics"}
+          </button>
+        </div>
+
+        {runMessage && (
+          <div className="px-3 py-2 rounded-lg bg-secondary/50 border border-border/50 text-xs text-muted-foreground">
+            {runMessage}
+          </div>
+        )}
+
+        {/* Loading state */}
+        {isLoading && communities.length === 0 && (
+          <div className="flex-1 flex items-center justify-center">
+            <Loader2 size={20} className="animate-spin text-muted-foreground" />
+          </div>
+        )}
+
+        {/* Tabs */}
+        <Tabs defaultValue="communities" className="flex-1 flex flex-col min-h-0">
+          <TabsList className="w-fit">
+            <TabsTrigger value="communities" className="text-xs">
+              Communities
+            </TabsTrigger>
+            <TabsTrigger value="trends" className="text-xs">
+              Trends
+            </TabsTrigger>
+            <TabsTrigger value="centrality" className="text-xs">
+              Centrality
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="communities" className="flex-1 overflow-auto mt-2">
+            <CommunityList
+              communities={communities}
+              totalCommunities={totalCommunities}
+            />
+          </TabsContent>
+
+          <TabsContent value="trends" className="flex-1 overflow-auto mt-2">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <TrendingChart
+                title="Top Methods"
+                items={methodTrends}
+                color="#22c55e"
+              />
+              <TrendingChart
+                title="Top Tasks"
+                items={taskTrends}
+                color="#a855f7"
+              />
+            </div>
+          </TabsContent>
+
+          <TabsContent value="centrality" className="flex-1 overflow-auto mt-2">
+            <CentralityTable members={centralityMembers} />
+          </TabsContent>
+        </Tabs>
       </div>
     </div>
   );

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -164,6 +164,48 @@ export interface NodeDetail {
   incoming: Array<{ from: string; type: string }>;
 }
 
+// /api/v1/analytics/run
+
+export interface AnalyticsRunResponse {
+  communities_detected: number;
+  authors_with_centrality: number;
+  methods_with_trends: number;
+  tasks_with_trends: number;
+  message: string;
+}
+
+// /api/v1/analytics/communities
+
+export interface CommunityMember {
+  uid: string;
+  name: string;
+  pagerank?: number;
+}
+
+export interface Community {
+  community_id: number;
+  member_count: number;
+  top_members: CommunityMember[];
+}
+
+export interface CommunitiesResponse {
+  total_communities: number;
+  communities: Community[];
+}
+
+// /api/v1/analytics/trends
+
+export interface TrendingItem {
+  uid: string;
+  name: string;
+  trend_score: number;
+}
+
+export interface TrendsResponse {
+  entity_type: string;
+  items: TrendingItem[];
+}
+
 // Client-side error type
 
 export class ApiError extends Error {


### PR DESCRIPTION
## Summary
- Add analytics TypeScript types and 3 API functions (runAnalytics, fetchCommunities, fetchTrends)
- Create CommunityList: expandable cards with member details and PageRank
- Create TrendingChart: CSS bar charts for top methods and top tasks
- Create CentralityTable: sortable table ranked by PageRank (aggregated from community data)
- Replace AnalyticsPage stub with 3-tab layout and Run Analytics button
- Install shadcn/ui tabs and table components

## Test plan
- [x] TypeScript compiles
- [x] Production build passes
- [ ] Visual QA: communities tab shows expandable list
- [ ] Visual QA: trends tab shows side-by-side bar charts
- [ ] Visual QA: centrality tab shows sortable table
- [ ] Run Analytics button triggers pipeline