### PR TITLE
feat(eval): evaluation dashboard with API and frontend #23

### DIFF
--- a/backend/src/graphrag_service/modules/eval/__init__.py
+++ b/backend/src/graphrag_service/modules/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Evaluation module — API endpoints for evaluation queries and reports."""

--- a/backend/src/graphrag_service/modules/eval/apiv1/handler.py
+++ b/backend/src/graphrag_service/modules/eval/apiv1/handler.py
@@ -1,0 +1,148 @@
+"""Evaluation API endpoints."""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from graphrag_service.core.config import get_settings
+from graphrag_service.core.dependencies import get_neo4j_client
+from graphrag_service.dbase.neo4j.client import Neo4jClient
+from graphrag_service.modules.rag.usecase import RAGUseCase
+from loguru import logger
+
+from ..schemas import EvalQueriesResponse, EvalQueryOut, EvalReportResponse, EvalResultOut
+
+router = APIRouter()
+
+# Cached report path
+_REPORT_DIR = Path(__file__).resolve().parent.parent.parent.parent.parent.parent / "data"
+
+
+def _get_report_path() -> Path:
+    return _REPORT_DIR / "eval_report_latest.json"
+
+
+def _get_all_queries():
+    """Import and return all evaluation queries."""
+    from tests.evaluation.queries import ALL_QUERIES
+    return ALL_QUERIES
+
+
+@router.get("/queries", response_model=EvalQueriesResponse)
+async def list_eval_queries(
+    category: str | None = Query(None, description="Filter by category"),
+):
+    """List all 40 evaluation queries (optionally filtered by category)."""
+    try:
+        queries = _get_all_queries()
+    except ImportError:
+        raise HTTPException(status_code=500, detail="Evaluation queries not available")
+
+    if category:
+        queries = [q for q in queries if q.category == category]
+
+    return EvalQueriesResponse(
+        queries=[
+            EvalQueryOut(
+                id=q.id,
+                category=q.category,
+                question=q.question,
+                difficulty=q.difficulty,
+                expected_entities=q.expected_entities,
+                min_hops=q.min_hops,
+            )
+            for q in queries
+        ],
+        count=len(queries),
+    )
+
+
+@router.post("/run", response_model=EvalReportResponse)
+async def run_evaluation(
+    category: str | None = Query(None, description="Run only specific category"),
+    client: Neo4jClient = Depends(get_neo4j_client),
+):
+    """Run evaluation suite and return report. Results are cached to disk."""
+    try:
+        from tests.evaluation.queries import ALL_QUERIES
+        from tests.evaluation.runner import EvaluationRunner
+    except ImportError:
+        raise HTTPException(status_code=500, detail="Evaluation framework not available")
+
+    queries = ALL_QUERIES
+    if category:
+        queries = [q for q in queries if q.category == category]
+
+    if not queries:
+        raise HTTPException(status_code=400, detail=f"No queries for category: {category}")
+
+    usecase = RAGUseCase(client)
+    runner = EvaluationRunner(pipeline_fn=usecase.query, queries=queries)
+
+    logger.info(f"eval.api.run_start queries={len(queries)}")
+    report = runner.run_all(system_name="graphrag")
+
+    # Cache report to disk
+    report_path = _get_report_path()
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(report.to_json())
+    logger.info(f"eval.api.run_done saved={report_path}")
+
+    return _report_to_response(report)
+
+
+@router.get("/report/latest", response_model=EvalReportResponse)
+async def get_latest_report():
+    """Get the latest cached evaluation report."""
+    report_path = _get_report_path()
+    if not report_path.exists():
+        raise HTTPException(status_code=404, detail="No evaluation report found. Run /eval/run first.")
+
+    try:
+        data = json.loads(report_path.read_text())
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to read report: {e}")
+
+    return EvalReportResponse(
+        timestamp=data.get("timestamp", ""),
+        system_name=data.get("system_name", ""),
+        total_queries=data.get("total_queries", 0),
+        successful_queries=data.get("successful_queries", 0),
+        metrics_summary=data.get("metrics_summary", {}),
+        metrics_by_category=data.get("metrics_by_category", {}),
+        failures=data.get("failures", []),
+        comparison=data.get("comparison"),
+        results=[
+            EvalResultOut(**r) for r in data.get("results", [])
+        ],
+    )
+
+
+def _report_to_response(report) -> EvalReportResponse:
+    """Convert EvaluationReport to API response."""
+    return EvalReportResponse(
+        timestamp=report.timestamp,
+        system_name=report.system_name,
+        total_queries=report.total_queries,
+        successful_queries=report.successful_queries,
+        metrics_summary=report.metrics_summary,
+        metrics_by_category=report.metrics_by_category,
+        failures=report.failures,
+        comparison=report.comparison,
+        results=[
+            EvalResultOut(
+                query_id=r.query_id,
+                category=r.category,
+                question=r.question,
+                answer=r.answer[:200],
+                latency_ms=r.latency_ms,
+                query_type=r.query_type,
+                retrieval_strategy=r.retrieval_strategy,
+                provenance_score=r.provenance_score,
+                metrics=r.metrics,
+            )
+            for r in report.results
+        ],
+    )

--- a/backend/src/graphrag_service/modules/eval/schemas.py
+++ b/backend/src/graphrag_service/modules/eval/schemas.py
@@ -1,0 +1,41 @@
+"""Pydantic schemas for evaluation API endpoints."""
+
+from pydantic import BaseModel, Field
+
+
+class EvalQueryOut(BaseModel):
+    id: str
+    category: str
+    question: str
+    difficulty: str
+    expected_entities: list[str] = Field(default_factory=list)
+    min_hops: int = 1
+
+
+class EvalQueriesResponse(BaseModel):
+    queries: list[EvalQueryOut]
+    count: int
+
+
+class EvalResultOut(BaseModel):
+    query_id: str
+    category: str
+    question: str
+    answer: str
+    latency_ms: int = 0
+    query_type: str = ""
+    retrieval_strategy: str = ""
+    provenance_score: float = 0.0
+    metrics: dict[str, float] = Field(default_factory=dict)
+
+
+class EvalReportResponse(BaseModel):
+    timestamp: str
+    system_name: str
+    total_queries: int
+    successful_queries: int
+    metrics_summary: dict[str, float] = Field(default_factory=dict)
+    metrics_by_category: dict[str, dict[str, float]] = Field(default_factory=dict)
+    failures: list[str] = Field(default_factory=list)
+    comparison: dict[str, dict] | None = None
+    results: list[EvalResultOut] = Field(default_factory=list)

--- a/backend/src/graphrag_service/router.py
+++ b/backend/src/graphrag_service/router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends
 from .core.auth import get_api_key
 from .modules.analytics.apiv1.handler import router as analytics_router
 from .modules.entity_resolution.apiv1.handler import router as er_router
+from .modules.eval.apiv1.handler import router as eval_router
 from .modules.graph.apiv1.handler import router as graph_router
 from .modules.health.apiv1.handler import router as health_router
 from .modules.rag.apiv1.handler import router as rag_router
@@ -28,4 +29,7 @@ api_router.include_router(
 )
 api_router.include_router(
     analytics_router, prefix="/v1/analytics", tags=["Analytics"], dependencies=[Depends(get_api_key)]
+)
+api_router.include_router(
+    eval_router, prefix="/v1/eval", tags=["Evaluation"], dependencies=[Depends(get_api_key)]
 )

--- a/frontend/src/components/CategoryBreakdown.tsx
+++ b/frontend/src/components/CategoryBreakdown.tsx
@@ -1,0 +1,69 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface CategoryBreakdownProps {
+  metricsByCategory: Record<string, Record<string, number>>;
+}
+
+const METRIC_COLS = ["entity_f1", "precision_at_10", "recall_at_10", "keyword_coverage", "provenance_score", "latency_ms"];
+const COL_LABELS: Record<string, string> = {
+  entity_f1: "F1",
+  precision_at_10: "P@10",
+  recall_at_10: "R@10",
+  keyword_coverage: "Keywords",
+  provenance_score: "Provenance",
+  latency_ms: "Latency",
+};
+
+export function CategoryBreakdown({ metricsByCategory }: CategoryBreakdownProps) {
+  const categories = Object.keys(metricsByCategory).sort();
+
+  if (categories.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-border/50 overflow-hidden">
+      <Table>
+        <TableHeader>
+          <TableRow className="bg-secondary/30">
+            <TableHead className="text-[11px]">Category</TableHead>
+            {METRIC_COLS.map((col) => (
+              <TableHead key={col} className="text-[11px] text-right">
+                {COL_LABELS[col] ?? col}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {categories.map((cat) => {
+            const metrics = metricsByCategory[cat];
+            return (
+              <TableRow key={cat}>
+                <TableCell className="text-xs font-medium">
+                  {cat.replace(/_/g, " ")}
+                </TableCell>
+                {METRIC_COLS.map((col) => {
+                  const val = metrics[col];
+                  return (
+                    <TableCell key={col} className="text-xs text-right tabular-nums text-muted-foreground">
+                      {val !== undefined
+                        ? col === "latency_ms"
+                          ? `${val.toFixed(0)}ms`
+                          : val.toFixed(3)
+                        : "—"}
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/frontend/src/components/MetricCards.tsx
+++ b/frontend/src/components/MetricCards.tsx
@@ -1,0 +1,41 @@
+interface MetricCardsProps {
+  metrics: Record<string, number>;
+}
+
+const METRIC_CONFIG: Record<string, { label: string; format: (v: number) => string; color: string }> = {
+  entity_f1: { label: "Entity F1", format: (v) => v.toFixed(3), color: "text-blue-500" },
+  precision_at_10: { label: "Precision@10", format: (v) => v.toFixed(3), color: "text-emerald-500" },
+  recall_at_10: { label: "Recall@10", format: (v) => v.toFixed(3), color: "text-violet-500" },
+  keyword_coverage: { label: "Keyword Coverage", format: (v) => v.toFixed(3), color: "text-amber-500" },
+  provenance_score: { label: "Provenance", format: (v) => v.toFixed(3), color: "text-cyan-500" },
+  latency_p95: { label: "Latency P95", format: (v) => `${v.toFixed(0)}ms`, color: "text-rose-500" },
+};
+
+const DISPLAY_ORDER = ["entity_f1", "precision_at_10", "recall_at_10", "keyword_coverage", "provenance_score", "latency_p95"];
+
+export function MetricCards({ metrics }: MetricCardsProps) {
+  const keys = DISPLAY_ORDER.filter((k) => k in metrics);
+
+  if (keys.length === 0) return null;
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2">
+      {keys.map((key) => {
+        const config = METRIC_CONFIG[key] ?? { label: key, format: (v: number) => v.toFixed(3), color: "text-foreground" };
+        return (
+          <div
+            key={key}
+            className="rounded-lg border border-border/50 bg-card p-3 text-center"
+          >
+            <div className={`text-xl font-bold tabular-nums ${config.color}`}>
+              {config.format(metrics[key])}
+            </div>
+            <div className="text-[10px] text-muted-foreground mt-1 uppercase tracking-wider">
+              {config.label}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/QueryDrillDown.tsx
+++ b/frontend/src/components/QueryDrillDown.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import type { EvalResultItem } from "@/types/api";
+
+interface QueryDrillDownProps {
+  results: EvalResultItem[];
+  categoryFilter: string | null;
+}
+
+export function QueryDrillDown({ results, categoryFilter }: QueryDrillDownProps) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const filtered = categoryFilter
+    ? results.filter((r) => r.category === categoryFilter)
+    : results;
+
+  // Group by category
+  const grouped: Record<string, EvalResultItem[]> = {};
+  for (const r of filtered) {
+    if (!grouped[r.category]) grouped[r.category] = [];
+    grouped[r.category].push(r);
+  }
+
+  if (filtered.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground text-center py-8">
+        No query results available.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {Object.entries(grouped)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([category, items]) => (
+          <div key={category}>
+            <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+              {category.replace(/_/g, " ")} ({items.length})
+            </h3>
+            <div className="space-y-1">
+              {items.map((r) => {
+                const isExpanded = expandedId === r.query_id;
+                return (
+                  <div
+                    key={r.query_id}
+                    className="rounded-lg border border-border/50 bg-card overflow-hidden"
+                  >
+                    <button
+                      onClick={() => setExpandedId(isExpanded ? null : r.query_id)}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-secondary/50 transition-colors"
+                    >
+                      {isExpanded ? (
+                        <ChevronDown size={14} className="text-muted-foreground shrink-0" />
+                      ) : (
+                        <ChevronRight size={14} className="text-muted-foreground shrink-0" />
+                      )}
+                      <span className="text-xs text-muted-foreground tabular-nums shrink-0 w-20">
+                        {r.query_id}
+                      </span>
+                      <span className="text-xs text-foreground/80 truncate flex-1">
+                        {r.question}
+                      </span>
+                      {r.metrics.entity_f1 !== undefined && (
+                        <span className="text-[10px] tabular-nums text-muted-foreground shrink-0">
+                          F1: {r.metrics.entity_f1.toFixed(2)}
+                        </span>
+                      )}
+                    </button>
+                    {isExpanded && (
+                      <div className="px-3 pb-3 pt-0 border-t border-border/30">
+                        <div className="pt-2 space-y-2">
+                          {/* Answer */}
+                          <div>
+                            <span className="text-[10px] text-muted-foreground uppercase tracking-wider">Answer</span>
+                            <p className="text-xs text-foreground/80 mt-0.5 whitespace-pre-wrap">
+                              {r.answer || "No answer"}
+                            </p>
+                          </div>
+                          {/* Metrics */}
+                          <div>
+                            <span className="text-[10px] text-muted-foreground uppercase tracking-wider">Metrics</span>
+                            <div className="flex flex-wrap gap-x-4 gap-y-1 mt-1">
+                              {Object.entries(r.metrics)
+                                .filter(([k]) => k !== "error")
+                                .map(([k, v]) => (
+                                  <span key={k} className="text-[11px]">
+                                    <span className="text-muted-foreground">{k.replace(/_/g, " ")}:</span>{" "}
+                                    <span className="font-medium tabular-nums">
+                                      {k.includes("latency") ? `${v.toFixed(0)}ms` : v.toFixed(3)}
+                                    </span>
+                                  </span>
+                                ))}
+                            </div>
+                          </div>
+                          {/* Meta */}
+                          <div className="flex gap-4 text-[10px] text-muted-foreground">
+                            {r.query_type && <span>Type: {r.query_type}</span>}
+                            {r.retrieval_strategy && <span>Strategy: {r.retrieval_strategy}</span>}
+                            <span>Latency: {r.latency_ms}ms</span>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8,6 +8,8 @@
 import type {
   AnalyticsRunResponse,
   CommunitiesResponse,
+  EvalQueriesResponse,
+  EvalReport,
   ExploreResponse,
   GraphStats,
   HealthResponse,
@@ -119,4 +121,24 @@ export async function fetchTrends(
   return apiFetch<TrendsResponse>(
     `/api/v1/analytics/trends?type=${type}&limit=${limit}`,
   );
+}
+
+export async function fetchEvalQueries(
+  category?: string,
+): Promise<EvalQueriesResponse> {
+  const params = category ? `?category=${encodeURIComponent(category)}` : "";
+  return apiFetch<EvalQueriesResponse>(`/api/v1/eval/queries${params}`);
+}
+
+export async function runEvaluation(
+  category?: string,
+): Promise<EvalReport> {
+  const params = category ? `?category=${encodeURIComponent(category)}` : "";
+  return apiFetch<EvalReport>(`/api/v1/eval/run${params}`, {
+    method: "POST",
+  });
+}
+
+export async function fetchLatestReport(): Promise<EvalReport> {
+  return apiFetch<EvalReport>("/api/v1/eval/report/latest");
 }

--- a/frontend/src/pages/EvaluationPage.tsx
+++ b/frontend/src/pages/EvaluationPage.tsx
@@ -1,15 +1,214 @@
-import { FlaskConical } from "lucide-react";
+import { useState, useEffect, useCallback } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { MetricCards } from "@/components/MetricCards";
+import { CategoryBreakdown } from "@/components/CategoryBreakdown";
+import { QueryDrillDown } from "@/components/QueryDrillDown";
+import { fetchLatestReport, runEvaluation } from "@/lib/api";
+import type { EvalReport } from "@/types/api";
+import { Loader2, Play, FlaskConical } from "lucide-react";
 
 export default function EvaluationPage() {
-  return (
-    <div className="flex-1 flex items-center justify-center">
-      <div className="text-center space-y-3">
-        <FlaskConical size={48} className="mx-auto text-muted-foreground/40" />
-        <h2 className="text-lg font-semibold text-foreground">Evaluation Dashboard</h2>
-        <p className="text-sm text-muted-foreground">
-          Test pipeline accuracy, metrics, and baselines. Coming in Phase E.
-        </p>
+  const [report, setReport] = useState<EvalReport | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
+
+  const loadReport = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const data = await fetchLatestReport();
+      setReport(data);
+    } catch {
+      // No cached report yet — that's fine
+      setReport(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadReport();
+  }, [loadReport]);
+
+  const handleRunEvaluation = async () => {
+    try {
+      setIsRunning(true);
+      setError(null);
+      const data = await runEvaluation(categoryFilter ?? undefined);
+      setReport(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Evaluation failed");
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <Loader2 className="animate-spin text-muted-foreground" size={32} />
       </div>
+    );
+  }
+
+  const categories = report
+    ? [...new Set(report.results.map((r) => r.category))].sort()
+    : [];
+
+  return (
+    <div className="flex-1 flex flex-col gap-4 p-4 overflow-auto">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <FlaskConical size={20} className="text-muted-foreground" />
+          <h1 className="text-lg font-semibold">Evaluation Dashboard</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          {categories.length > 0 && (
+            <select
+              value={categoryFilter ?? ""}
+              onChange={(e) => setCategoryFilter(e.target.value || null)}
+              className="text-xs border border-border rounded-md px-2 py-1.5 bg-background text-foreground"
+            >
+              <option value="">All categories</option>
+              {categories.map((cat) => (
+                <option key={cat} value={cat}>
+                  {cat.replace(/_/g, " ")}
+                </option>
+              ))}
+            </select>
+          )}
+          <button
+            onClick={handleRunEvaluation}
+            disabled={isRunning}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+          >
+            {isRunning ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <Play size={14} />
+            )}
+            {isRunning ? "Running…" : "Run Evaluation"}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/5 px-3 py-2 text-xs text-red-600 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      {!report ? (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-center space-y-3">
+            <FlaskConical size={48} className="mx-auto text-muted-foreground/40" />
+            <p className="text-sm text-muted-foreground">
+              No evaluation report found. Click &quot;Run Evaluation&quot; to start.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <Tabs defaultValue="overview" className="flex-1 flex flex-col">
+          <TabsList className="w-fit">
+            <TabsTrigger value="overview" className="text-xs">Overview</TabsTrigger>
+            <TabsTrigger value="baselines" className="text-xs">Baselines</TabsTrigger>
+            <TabsTrigger value="queries" className="text-xs">Queries</TabsTrigger>
+          </TabsList>
+
+          {/* Overview Tab */}
+          <TabsContent value="overview" className="flex-1 space-y-4 mt-3">
+            <div className="flex items-center gap-4 text-xs text-muted-foreground">
+              <span>System: {report.system_name}</span>
+              <span>Queries: {report.successful_queries}/{report.total_queries}</span>
+              <span>{report.timestamp}</span>
+            </div>
+
+            <MetricCards metrics={report.metrics_summary} />
+            <CategoryBreakdown metricsByCategory={report.metrics_by_category} />
+
+            {report.failures.length > 0 && (
+              <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-3">
+                <h3 className="text-xs font-medium text-red-600 dark:text-red-400 mb-1">
+                  Failures ({report.failures.length})
+                </h3>
+                <ul className="text-[11px] text-red-600/80 dark:text-red-400/80 space-y-0.5">
+                  {report.failures.map((f, i) => (
+                    <li key={i}>{f}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </TabsContent>
+
+          {/* Baselines Tab */}
+          <TabsContent value="baselines" className="flex-1 mt-3">
+            {report.comparison ? (
+              <BaselineTable comparison={report.comparison} />
+            ) : (
+              <p className="text-sm text-muted-foreground text-center py-8">
+                No baseline comparison available. Run evaluation with a baseline to compare.
+              </p>
+            )}
+          </TabsContent>
+
+          {/* Queries Tab */}
+          <TabsContent value="queries" className="flex-1 mt-3">
+            <QueryDrillDown results={report.results} categoryFilter={categoryFilter} />
+          </TabsContent>
+        </Tabs>
+      )}
+    </div>
+  );
+}
+
+/* ---------- Inline BaselineTable ---------- */
+
+interface BaselineTableProps {
+  comparison: Record<string, Record<string, number>>;
+}
+
+function BaselineTable({ comparison }: BaselineTableProps) {
+  const systems = Object.keys(comparison);
+  if (systems.length === 0) return null;
+
+  const metricKeys = [...new Set(systems.flatMap((s) => Object.keys(comparison[s])))].sort();
+
+  return (
+    <div className="rounded-lg border border-border/50 overflow-hidden">
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="bg-secondary/30">
+            <th className="text-left px-3 py-2 text-muted-foreground font-medium">Metric</th>
+            {systems.map((s) => (
+              <th key={s} className="text-right px-3 py-2 text-muted-foreground font-medium">
+                {s}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {metricKeys.map((metric) => (
+            <tr key={metric} className="border-t border-border/30">
+              <td className="px-3 py-1.5 text-foreground/80">{metric.replace(/_/g, " ")}</td>
+              {systems.map((s) => {
+                const val = comparison[s]?.[metric];
+                return (
+                  <td key={s} className="text-right px-3 py-1.5 tabular-nums text-muted-foreground">
+                    {val !== undefined
+                      ? metric.includes("latency")
+                        ? `${val.toFixed(0)}ms`
+                        : val.toFixed(3)
+                      : "—"}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -225,6 +225,48 @@ export interface TrendsResponse {
   items: TrendingItem[];
 }
 
+// /api/v1/eval/queries
+
+export interface EvalQueryInfo {
+  id: string;
+  category: string;
+  question: string;
+  difficulty: string;
+  expected_entities: string[];
+  min_hops: number;
+}
+
+export interface EvalQueriesResponse {
+  queries: EvalQueryInfo[];
+  count: number;
+}
+
+// /api/v1/eval/run & /api/v1/eval/report/latest
+
+export interface EvalResultItem {
+  query_id: string;
+  category: string;
+  question: string;
+  answer: string;
+  latency_ms: number;
+  query_type: string;
+  retrieval_strategy: string;
+  provenance_score: number;
+  metrics: Record<string, number>;
+}
+
+export interface EvalReport {
+  timestamp: string;
+  system_name: string;
+  total_queries: number;
+  successful_queries: number;
+  metrics_summary: Record<string, number>;
+  metrics_by_category: Record<string, Record<string, number>>;
+  failures: string[];
+  comparison: Record<string, Record<string, number>> | null;
+  results: EvalResultItem[];
+}
+
 // Client-side error type
 
 export class ApiError extends Error {


### PR DESCRIPTION
## Summary
- **Backend**: New `eval` module with 3 API endpoints (`GET /queries`, `POST /run`, `GET /report/latest`) wrapping the existing CLI evaluation framework (40 queries, 7 categories, 6 metrics)
- **Frontend**: Full EvaluationPage with 3 tabs — Overview (MetricCards + CategoryBreakdown + failures), Baselines (comparison table), Queries (QueryDrillDown with expand/collapse per query)
- **Components**: MetricCards (6 color-coded metric cards), CategoryBreakdown (7×6 table), QueryDrillDown (grouped by category, expandable details)

## Test plan
- [ ] `GET /api/v1/eval/queries` returns 40 queries
- [ ] `POST /api/v1/eval/run` executes evaluation and caches report
- [ ] `GET /api/v1/eval/report/latest` returns cached report
- [ ] Frontend loads cached report on page load
- [ ] Run Evaluation button triggers eval and updates dashboard
- [ ] Category filter dropdown filters queries tab
- [ ] All 3 tabs render correctly with report data

🤖 Generated with [Claude Code](https://claude.com/claude-code)