### PR TITLE
feat: richer graph structure with new relationships and node types #45

### DIFF
--- a/backend/src/graphrag_service/dbase/neo4j/models/__init__.py
+++ b/backend/src/graphrag_service/dbase/neo4j/models/__init__.py
@@ -1,8 +1,17 @@
 """Neo4j models — neomodel StructuredNode and StructuredRel definitions."""
 
 from .base import BaseNode
-from .nodes import ALL_MODELS, ALL_NODE_MODELS, Author, Dataset, Method, Paper, Task
-from .relationships import AuthoredRel, CoAuthoredWithRel, EvaluatedOnRel, UsedForRel
+from .nodes import ALL_MODELS, ALL_NODE_MODELS, Author, Dataset, Method, Paper, Repository, Task
+from .relationships import (
+    AddressesTaskRel,
+    AuthoredRel,
+    CoAuthoredWithRel,
+    EvaluatedOnRel,
+    HasCodeRel,
+    IntroducesMethodRel,
+    UsedForRel,
+    UsesMethodRel,
+)
 
 __all__ = [
     "BaseNode",
@@ -11,10 +20,15 @@ __all__ = [
     "Method",
     "Task",
     "Dataset",
+    "Repository",
     "ALL_NODE_MODELS",
     "ALL_MODELS",
     "UsedForRel",
     "EvaluatedOnRel",
     "AuthoredRel",
     "CoAuthoredWithRel",
+    "UsesMethodRel",
+    "IntroducesMethodRel",
+    "AddressesTaskRel",
+    "HasCodeRel",
 ]

--- a/backend/src/graphrag_service/dbase/neo4j/models/nodes.py
+++ b/backend/src/graphrag_service/dbase/neo4j/models/nodes.py
@@ -7,10 +7,19 @@ Each model inherits from BaseNode (uid + created_at) and declares:
 - Relationships via RelationshipTo / RelationshipFrom
 """
 
-from neomodel import ArrayProperty, FloatProperty, IntegerProperty, RelationshipFrom, RelationshipTo, StringProperty
+from neomodel import ArrayProperty, BooleanProperty, FloatProperty, IntegerProperty, RelationshipFrom, RelationshipTo, StringProperty
 
 from .base import BaseNode
-from .relationships import AuthoredRel, CoAuthoredWithRel, EvaluatedOnRel, UsedForRel
+from .relationships import (
+    AddressesTaskRel,
+    AuthoredRel,
+    CoAuthoredWithRel,
+    EvaluatedOnRel,
+    HasCodeRel,
+    IntroducesMethodRel,
+    UsedForRel,
+    UsesMethodRel,
+)
 
 
 class Author(BaseNode):
@@ -49,7 +58,10 @@ class Paper(BaseNode):
     title = StringProperty(required=True)
     abstract = StringProperty()
     year = StringProperty()
+    arxiv_id = StringProperty(index=True)
     url = StringProperty()
+    url_pdf = StringProperty()
+    date = StringProperty()
     embedding = ArrayProperty(base_property=FloatProperty())
 
     # Analytics
@@ -58,6 +70,18 @@ class Paper(BaseNode):
     # Paper <-[:AUTHORED]- Author
     authors = RelationshipFrom("Author", "AUTHORED", model=AuthoredRel)
 
+    # Paper -[:USES_METHOD]-> Method
+    methods_used = RelationshipTo("Method", "USES_METHOD", model=UsesMethodRel)
+
+    # Paper -[:INTRODUCES_METHOD]-> Method
+    methods_introduced = RelationshipTo("Method", "INTRODUCES_METHOD", model=IntroducesMethodRel)
+
+    # Paper -[:ADDRESSES_TASK]-> Task
+    tasks_addressed = RelationshipTo("Task", "ADDRESSES_TASK", model=AddressesTaskRel)
+
+    # Paper -[:HAS_CODE]-> Repository
+    repositories = RelationshipTo("Repository", "HAS_CODE", model=HasCodeRel)
+
 
 class Method(BaseNode):
     """ML method / model node."""
@@ -65,6 +89,8 @@ class Method(BaseNode):
     name = StringProperty(required=True, index=True)
     full_name = StringProperty()
     description = StringProperty()
+    category = StringProperty(index=True)
+    introduced_year = IntegerProperty()
     embedding = ArrayProperty(base_property=FloatProperty())
 
     # Analytics
@@ -73,6 +99,12 @@ class Method(BaseNode):
 
     # Method -[:EVALUATED_ON]-> Dataset
     evaluated_on = RelationshipTo("Dataset", "EVALUATED_ON", model=EvaluatedOnRel)
+
+    # Method <-[:USES_METHOD]- Paper
+    used_by_papers = RelationshipFrom("Paper", "USES_METHOD", model=UsesMethodRel)
+
+    # Method <-[:INTRODUCES_METHOD]- Paper
+    introduced_by_paper = RelationshipFrom("Paper", "INTRODUCES_METHOD", model=IntroducesMethodRel)
 
 
 class Task(BaseNode):
@@ -89,6 +121,9 @@ class Task(BaseNode):
     # Task <-[:USED_FOR]- Dataset
     datasets = RelationshipFrom("Dataset", "USED_FOR", model=UsedForRel)
 
+    # Task <-[:ADDRESSES_TASK]- Paper
+    addressed_by_papers = RelationshipFrom("Paper", "ADDRESSES_TASK", model=AddressesTaskRel)
+
 
 class Dataset(BaseNode):
     """Dataset node."""
@@ -96,6 +131,8 @@ class Dataset(BaseNode):
     name = StringProperty(required=True, index=True)
     description = StringProperty()
     modalities = StringProperty()
+    num_papers = IntegerProperty()
+    url = StringProperty()
     embedding = ArrayProperty(base_property=FloatProperty())
 
     # Dataset -[:USED_FOR]-> Task
@@ -104,8 +141,20 @@ class Dataset(BaseNode):
     evaluated_by = RelationshipFrom("Method", "EVALUATED_ON", model=EvaluatedOnRel)
 
 
+class Repository(BaseNode):
+    """Code repository node (e.g., GitHub)."""
+
+    url = StringProperty(required=True, unique_index=True)
+    framework = StringProperty()
+    stars = IntegerProperty()
+    is_official = BooleanProperty(default=False)
+
+    # Repository <-[:HAS_CODE]- Paper
+    papers = RelationshipFrom("Paper", "HAS_CODE", model=HasCodeRel)
+
+
 # Registry of all node models (Author excluded — has no embedding/vector index)
 ALL_NODE_MODELS: list[type[BaseNode]] = [Paper, Method, Task, Dataset]
 
-# All models including Author (for schema installation)
-ALL_MODELS: list[type[BaseNode]] = [Author, Paper, Method, Task, Dataset]
+# All models including Author and Repository (for schema installation)
+ALL_MODELS: list[type[BaseNode]] = [Author, Paper, Method, Task, Dataset, Repository]

--- a/backend/src/graphrag_service/dbase/neo4j/models/relationships.py
+++ b/backend/src/graphrag_service/dbase/neo4j/models/relationships.py
@@ -4,7 +4,7 @@ Neo4j relationship models for the GraphRAG knowledge graph.
 Uses neomodel StructuredRel for typed relationship properties.
 """
 
-from neomodel import IntegerProperty, StringProperty, StructuredRel
+from neomodel import BooleanProperty, IntegerProperty, StringProperty, StructuredRel
 
 
 class UsedForRel(StructuredRel):
@@ -34,3 +34,27 @@ class CoAuthoredWithRel(StructuredRel):
     """Author -[:CO_AUTHORED_WITH]-> Author. Derived from shared papers."""
 
     paper_count = IntegerProperty(default=0)
+
+
+class UsesMethodRel(StructuredRel):
+    """Paper -[:USES_METHOD]-> Method."""
+
+    pass
+
+
+class IntroducesMethodRel(StructuredRel):
+    """Paper -[:INTRODUCES_METHOD]-> Method."""
+
+    pass
+
+
+class AddressesTaskRel(StructuredRel):
+    """Paper -[:ADDRESSES_TASK]-> Task."""
+
+    pass
+
+
+class HasCodeRel(StructuredRel):
+    """Paper -[:HAS_CODE]-> Repository."""
+
+    is_official = BooleanProperty(default=False)

--- a/backend/src/graphrag_service/library/graph/graph_retriever.py
+++ b/backend/src/graphrag_service/library/graph/graph_retriever.py
@@ -45,10 +45,12 @@ CYPHER_TEMPLATES: dict[str, str] = {
            OR p.title =~ $pattern
         OPTIONAL MATCH (p)<-[:AUTHORED]-(coauthor:Author)
         WHERE coauthor <> a
-        OPTIONAL MATCH (p)-[:ADDRESSES]->(t:Task)
+        OPTIONAL MATCH (p)-[:ADDRESSES_TASK]->(t:Task)
+        OPTIONAL MATCH (p)-[:USES_METHOD]->(m:Method)
         RETURN a, labels(a)[0] AS a_label, p, labels(p)[0] AS p_label,
                collect(DISTINCT coauthor)[..20] AS coauthors,
-               collect(DISTINCT t.name)[..10] AS tasks
+               collect(DISTINCT t.name)[..10] AS tasks,
+               collect(DISTINCT m.name)[..10] AS methods
         LIMIT 20
     """,
 }

--- a/backend/src/graphrag_service/library/parsers.py
+++ b/backend/src/graphrag_service/library/parsers.py
@@ -35,12 +35,16 @@ def iter_papers(
             continue
         if limit > 0 and yielded >= limit:
             return
+        date_raw = p.get("date") or p.get("published") or ""
         yield {
             "uid": p.get("paper_url", p.get("id", "")),
             "title": p["title"].strip(),
             "abstract": p["abstract"].strip()[:2000],
-            "year": p.get("published", "")[:4],
+            "year": str(date_raw)[:4] if date_raw else "",
             "url": p.get("paper_url", ""),
+            "arxiv_id": p.get("arxiv_id") or "",
+            "url_pdf": p.get("url_pdf") or "",
+            "date": str(date_raw)[:10] if date_raw else "",
         }
         yielded += 1
 
@@ -60,11 +64,16 @@ def iter_methods(
             continue
         if limit > 0 and yielded >= limit:
             return
+        # Extract category from collections
+        collections = m.get("collections") or []
+        category = collections[0].get("area", "") if collections else ""
         yield {
             "uid": m.get("id", m["name"]),
             "name": m["name"].strip(),
             "full_name": (m.get("full_name") or m["name"]).strip(),
             "description": (m.get("description") or "")[:2000],
+            "category": category,
+            "introduced_year": m.get("introduced_year"),
         }
         yielded += 1
 
@@ -113,6 +122,8 @@ def iter_datasets(
             "name": d["name"].strip(),
             "description": (d.get("description") or "")[:1000],
             "modalities": ", ".join(d.get("modalities") or []),
+            "num_papers": d.get("num_papers"),
+            "url": d.get("url") or d.get("homepage") or "",
         }
         yielded += 1
 
@@ -133,6 +144,61 @@ def iter_authors(data: list, max_papers: int = 5000) -> Iterator[dict]:
                 continue
             seen.add(name)
             yield {"uid": f"author:{name.lower().replace(' ', '_')}", "name": name}
+
+
+def iter_paper_method_edges(
+    data: list, max_papers: int = 5000
+) -> Iterator[dict]:
+    """Extract paper→method edges from papers JSON.
+
+    Yields dicts with keys: paper_uid, method_name.
+    Source: papers.json → methods[] field.
+    """
+    papers = data[:max_papers] if max_papers > 0 else data
+    for p in papers:
+        if not p.get("title") or not p.get("abstract"):
+            continue
+        paper_uid = p.get("paper_url", p.get("id", ""))
+        for m in p.get("methods") or []:
+            method_name = (m.get("name") or "").strip()
+            if method_name:
+                yield {"paper_uid": paper_uid, "method_name": method_name}
+
+
+def iter_paper_task_edges(
+    data: list, max_papers: int = 5000
+) -> Iterator[dict]:
+    """Extract paper→task edges from papers JSON.
+
+    Yields dicts with keys: paper_uid, task_name.
+    Source: papers.json → tasks[] field.
+    """
+    papers = data[:max_papers] if max_papers > 0 else data
+    for p in papers:
+        if not p.get("title") or not p.get("abstract"):
+            continue
+        paper_uid = p.get("paper_url", p.get("id", ""))
+        for task_name in p.get("tasks") or []:
+            task_name = (task_name or "").strip()
+            if task_name:
+                yield {"paper_uid": paper_uid, "task_name": task_name}
+
+
+def iter_method_paper_edges(
+    data: list, max_items: int = 0
+) -> Iterator[dict]:
+    """Extract method→introducing paper edges from methods JSON.
+
+    Yields dicts with keys: method_name, paper_url.
+    Source: methods.json → paper.url field.
+    """
+    items = data[:max_items] if max_items > 0 else data
+    for m in items:
+        method_name = (m.get("name") or "").strip()
+        paper = m.get("paper") or {}
+        paper_url = (paper.get("url") or "").strip()
+        if method_name and paper_url:
+            yield {"method_name": method_name, "paper_url": paper_url}
 
 
 def iter_author_paper_edges(

--- a/backend/src/graphrag_service/modules/graph/repositories.py
+++ b/backend/src/graphrag_service/modules/graph/repositories.py
@@ -19,22 +19,30 @@ EXPLORE_QUERY = """
 CALL {
     MATCH (a:Author)-[r:AUTHORED]->(b:Paper)
     RETURN a, type(r) AS rel, b
-    LIMIT toInteger($limit * 0.3)
+    LIMIT toInteger($limit * 0.2)
   UNION ALL
     MATCH (a:Paper)-[r:USES_METHOD]->(b:Method)
     RETURN a, type(r) AS rel, b
-    LIMIT toInteger($limit * 0.2)
+    LIMIT toInteger($limit * 0.15)
+  UNION ALL
+    MATCH (a:Paper)-[r:ADDRESSES_TASK]->(b:Task)
+    RETURN a, type(r) AS rel, b
+    LIMIT toInteger($limit * 0.15)
   UNION ALL
     MATCH (a:Method)-[r:EVALUATED_ON]->(b:Dataset)
     RETURN a, type(r) AS rel, b
-    LIMIT toInteger($limit * 0.2)
+    LIMIT toInteger($limit * 0.15)
   UNION ALL
     MATCH (a:Dataset)-[r:USED_FOR]->(b:Task)
     RETURN a, type(r) AS rel, b
-    LIMIT toInteger($limit * 0.2)
+    LIMIT toInteger($limit * 0.15)
+  UNION ALL
+    MATCH (a:Paper)-[r:HAS_CODE]->(b:Repository)
+    RETURN a, type(r) AS rel, b
+    LIMIT toInteger($limit * 0.1)
   UNION ALL
     MATCH (a)-[r]->(b)
-    WHERE NOT type(r) IN ['AUTHORED', 'USES_METHOD', 'EVALUATED_ON', 'USED_FOR']
+    WHERE NOT type(r) IN ['AUTHORED', 'USES_METHOD', 'ADDRESSES_TASK', 'EVALUATED_ON', 'USED_FOR', 'HAS_CODE']
     RETURN a, type(r) AS rel, b
     LIMIT toInteger($limit * 0.1)
 }
@@ -248,6 +256,45 @@ class NodeRepository:
             "MATCH (p:Paper {uid: row.puid}) "
             "MERGE (a)-[r:AUTHORED]->(p) "
             "SET r.order = row.order",
+            {"rows": rows},
+        )
+        return len(rows)
+
+    def batch_merge_uses_method(self, rows: list[dict]) -> int:
+        """Batch MERGE Paper-[:USES_METHOD]->Method. rows: [{paper_uid, method_name}]"""
+        if not rows:
+            return 0
+        self._client.run_query(
+            "UNWIND $rows AS row "
+            "MATCH (p:Paper {uid: row.paper_uid}) "
+            "MATCH (m:Method {name: row.method_name}) "
+            "MERGE (p)-[:USES_METHOD]->(m)",
+            {"rows": rows},
+        )
+        return len(rows)
+
+    def batch_merge_addresses_task(self, rows: list[dict]) -> int:
+        """Batch MERGE Paper-[:ADDRESSES_TASK]->Task. rows: [{paper_uid, task_name}]"""
+        if not rows:
+            return 0
+        self._client.run_query(
+            "UNWIND $rows AS row "
+            "MATCH (p:Paper {uid: row.paper_uid}) "
+            "MATCH (t:Task {name: row.task_name}) "
+            "MERGE (p)-[:ADDRESSES_TASK]->(t)",
+            {"rows": rows},
+        )
+        return len(rows)
+
+    def batch_merge_introduces_method(self, rows: list[dict]) -> int:
+        """Batch MERGE Paper-[:INTRODUCES_METHOD]->Method. rows: [{paper_url, method_name}]"""
+        if not rows:
+            return 0
+        self._client.run_query(
+            "UNWIND $rows AS row "
+            "MATCH (p:Paper {uid: row.paper_url}) "
+            "MATCH (m:Method {name: row.method_name}) "
+            "MERGE (p)-[:INTRODUCES_METHOD]->(m)",
             {"rows": rows},
         )
         return len(rows)

--- a/backend/src/graphrag_service/modules/graph/usecase.py
+++ b/backend/src/graphrag_service/modules/graph/usecase.py
@@ -14,7 +14,14 @@ from loguru import logger
 from graphrag_service.core.config import get_settings
 from graphrag_service.dbase.neo4j.client import Neo4jClient
 from graphrag_service.dbase.neo4j.models import Author, Dataset, Method, Paper, Task
-from graphrag_service.library.parsers import iter_authors, iter_author_paper_edges, load_json
+from graphrag_service.library.parsers import (
+    iter_authors,
+    iter_author_paper_edges,
+    iter_method_paper_edges,
+    iter_paper_method_edges,
+    iter_paper_task_edges,
+    load_json,
+)
 from graphrag_service.modules.graph.author_ingestion import (
     run_entity_resolution, prepare_author_nodes, prepare_coauthor_edges,
 )
@@ -297,6 +304,53 @@ class GraphUseCase:
 
         auth_total += self.node_repo.batch_merge_authored(authored_batch)
         logger.info(f"AUTHORED: {auth_total} edges")
+
+        # Phase 3: USES_METHOD + ADDRESSES_TASK from papers.json
+        logger.info("Ingesting USES_METHOD + ADDRESSES_TASK relationships...")
+
+        uses_method_batch: list[dict] = []
+        um_total = 0
+        for edge in tqdm(
+            iter_paper_method_edges(papers_data, max_papers=settings.MAX_PAPERS),
+            desc="USES_METHOD",
+        ):
+            uses_method_batch.append(edge)
+            if len(uses_method_batch) >= batch_size:
+                um_total += self.node_repo.batch_merge_uses_method(uses_method_batch)
+                uses_method_batch = []
+        um_total += self.node_repo.batch_merge_uses_method(uses_method_batch)
+        logger.info(f"USES_METHOD: {um_total} edges")
+
+        addresses_task_batch: list[dict] = []
+        at_total = 0
+        for edge in tqdm(
+            iter_paper_task_edges(papers_data, max_papers=settings.MAX_PAPERS),
+            desc="ADDRESSES_TASK",
+        ):
+            addresses_task_batch.append(edge)
+            if len(addresses_task_batch) >= batch_size:
+                at_total += self.node_repo.batch_merge_addresses_task(addresses_task_batch)
+                addresses_task_batch = []
+        at_total += self.node_repo.batch_merge_addresses_task(addresses_task_batch)
+        logger.info(f"ADDRESSES_TASK: {at_total} edges")
+
+        # Phase 4: INTRODUCES_METHOD from methods.json
+        logger.info("Ingesting INTRODUCES_METHOD relationships...")
+        methods_data = load_json(self.service.data_dir() / "methods.json")
+
+        introduces_batch: list[dict] = []
+        im_total = 0
+        for edge in tqdm(
+            iter_method_paper_edges(methods_data, max_items=settings.MAX_METHODS),
+            desc="INTRODUCES_METHOD",
+        ):
+            introduces_batch.append(edge)
+            if len(introduces_batch) >= batch_size:
+                im_total += self.node_repo.batch_merge_introduces_method(introduces_batch)
+                introduces_batch = []
+        im_total += self.node_repo.batch_merge_introduces_method(introduces_batch)
+        logger.info(f"INTRODUCES_METHOD: {im_total} edges")
+
         logger.info("Relationships ingestion done")
 
     def ingest_authors(self, batch_size: int = 500) -> dict:

--- a/backend/tests/unit/library/test_parsers.py
+++ b/backend/tests/unit/library/test_parsers.py
@@ -6,7 +6,10 @@ from graphrag_service.library.parsers import (
     iter_author_paper_edges,
     iter_authors,
     iter_datasets,
+    iter_method_paper_edges,
     iter_methods,
+    iter_paper_method_edges,
+    iter_paper_task_edges,
     iter_papers,
     iter_tasks,
 )
@@ -225,3 +228,143 @@ class TestIterAuthorPaperEdges:
         edges = list(iter_author_paper_edges(data, max_papers=1))
         assert len(edges) == 1
         assert edges[0]["author_name"] == "Alice"
+
+
+class TestIterPaperMethodEdges:
+    def test_basic(self):
+        data = [
+            {
+                "title": "P1", "abstract": "A1", "paper_url": "http://p1",
+                "methods": [{"name": "ResNet"}, {"name": "BatchNorm"}],
+            },
+        ]
+        edges = list(iter_paper_method_edges(data))
+        assert len(edges) == 2
+        assert edges[0]["paper_uid"] == "http://p1"
+        assert edges[0]["method_name"] == "ResNet"
+        assert edges[1]["method_name"] == "BatchNorm"
+
+    def test_skips_empty_method_name(self):
+        data = [
+            {"title": "P1", "abstract": "A1", "paper_url": "u", "methods": [{"name": ""}, {"name": "Valid"}]},
+        ]
+        edges = list(iter_paper_method_edges(data))
+        assert len(edges) == 1
+        assert edges[0]["method_name"] == "Valid"
+
+    def test_skips_paper_without_title(self):
+        data = [{"abstract": "A1", "methods": [{"name": "M1"}]}]
+        assert list(iter_paper_method_edges(data)) == []
+
+    def test_no_methods_key(self):
+        data = [{"title": "P1", "abstract": "A1", "paper_url": "u"}]
+        assert list(iter_paper_method_edges(data)) == []
+
+
+class TestIterPaperTaskEdges:
+    def test_basic(self):
+        data = [
+            {
+                "title": "P1", "abstract": "A1", "paper_url": "http://p1",
+                "tasks": ["Image Classification", "Object Detection"],
+            },
+        ]
+        edges = list(iter_paper_task_edges(data))
+        assert len(edges) == 2
+        assert edges[0]["paper_uid"] == "http://p1"
+        assert edges[0]["task_name"] == "Image Classification"
+
+    def test_skips_empty_task_name(self):
+        data = [
+            {"title": "P1", "abstract": "A1", "paper_url": "u", "tasks": ["", "Valid"]},
+        ]
+        edges = list(iter_paper_task_edges(data))
+        assert len(edges) == 1
+
+    def test_no_tasks_key(self):
+        data = [{"title": "P1", "abstract": "A1", "paper_url": "u"}]
+        assert list(iter_paper_task_edges(data)) == []
+
+
+class TestIterMethodPaperEdges:
+    def test_basic(self):
+        data = [
+            {"name": "ResNet", "paper": {"url": "http://resnet-paper"}},
+        ]
+        edges = list(iter_method_paper_edges(data))
+        assert len(edges) == 1
+        assert edges[0]["method_name"] == "ResNet"
+        assert edges[0]["paper_url"] == "http://resnet-paper"
+
+    def test_skips_missing_paper(self):
+        data = [{"name": "ResNet"}]
+        assert list(iter_method_paper_edges(data)) == []
+
+    def test_skips_empty_paper_url(self):
+        data = [{"name": "ResNet", "paper": {"url": ""}}]
+        assert list(iter_method_paper_edges(data)) == []
+
+    def test_skips_missing_name(self):
+        data = [{"paper": {"url": "http://paper"}}]
+        assert list(iter_method_paper_edges(data)) == []
+
+
+class TestNewPaperFields:
+    def test_arxiv_id_and_date(self):
+        data = [
+            {
+                "title": "P1", "abstract": "A1", "paper_url": "u",
+                "arxiv_id": "2301.12345", "url_pdf": "http://pdf",
+                "date": "2023-01-15",
+            },
+        ]
+        results = list(iter_papers(data))
+        assert results[0]["arxiv_id"] == "2301.12345"
+        assert results[0]["url_pdf"] == "http://pdf"
+        assert results[0]["date"] == "2023-01-15"
+        assert results[0]["year"] == "2023"
+
+    def test_missing_new_fields_default_empty(self):
+        data = [{"title": "P1", "abstract": "A1", "paper_url": "u"}]
+        results = list(iter_papers(data))
+        assert results[0]["arxiv_id"] == ""
+        assert results[0]["url_pdf"] == ""
+        assert results[0]["date"] == ""
+
+
+class TestNewMethodFields:
+    def test_category_from_collections(self):
+        data = [
+            {
+                "name": "ResNet",
+                "collections": [{"area": "Computer Vision", "collection": "CNNs"}],
+            },
+        ]
+        results = list(iter_methods(data))
+        assert results[0]["category"] == "Computer Vision"
+
+    def test_introduced_year(self):
+        data = [{"name": "ResNet", "introduced_year": 2015}]
+        results = list(iter_methods(data))
+        assert results[0]["introduced_year"] == 2015
+
+    def test_no_collections(self):
+        data = [{"name": "M1"}]
+        results = list(iter_methods(data))
+        assert results[0]["category"] == ""
+
+
+class TestNewDatasetFields:
+    def test_num_papers_and_url(self):
+        data = [
+            {"name": "MNIST", "num_papers": 7651, "homepage": "http://mnist"},
+        ]
+        results = list(iter_datasets(data))
+        assert results[0]["num_papers"] == 7651
+        assert results[0]["url"] == "http://mnist"
+
+    def test_missing_new_fields(self):
+        data = [{"name": "D1"}]
+        results = list(iter_datasets(data))
+        assert results[0]["num_papers"] is None
+        assert results[0]["url"] == ""

--- a/backend/tests/unit/modules/graph/test_handler.py
+++ b/backend/tests/unit/modules/graph/test_handler.py
@@ -56,13 +56,14 @@ class TestGraphStatsEndpoint:
         mock_neo4j_client.run_query.side_effect = [
             [{"c": 5}],   # Author
             [{"c": 10}], [{"c": 20}], [{"c": 30}], [{"c": 40}],
+            [{"c": 2}],   # Repository
             [{"t": "USED_FOR"}],
             [{"c": 5}],
         ]
         resp = client.get("/api/v1/graph/stats", headers=auth_headers)
         assert resp.status_code == 200
         data = resp.json()
-        assert data["total_nodes"] == 105
+        assert data["total_nodes"] == 107
         assert "node_counts" in data
 
 

--- a/backend/tests/unit/modules/graph/test_repositories.py
+++ b/backend/tests/unit/modules/graph/test_repositories.py
@@ -142,13 +142,14 @@ class TestGraphExploreRepository:
             [{"c": 20}],  # Method
             [{"c": 30}],  # Task
             [{"c": 40}],  # Dataset
+            [{"c": 2}],   # Repository
             [{"t": "USED_FOR"}, {"t": "EVALUATED_ON"}],
             [{"c": 5}],
             [{"c": 3}],
         ]
         repo = GraphExploreRepository(mock_neo4j_client)
         stats = repo.get_stats()
-        assert stats["total_nodes"] == 105
+        assert stats["total_nodes"] == 107
         assert stats["total_edges"] == 8
         assert stats["node_counts"]["Paper"] == 10
         assert stats["edge_counts"]["USED_FOR"] == 5

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -16,6 +16,7 @@ const BADGE_COLORS: Record<string, string> = {
   Method: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20",
   Task: "bg-purple-500/10 text-purple-600 dark:text-purple-400 border-purple-500/20",
   Dataset: "bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/20",
+  Repository: "bg-pink-500/10 text-pink-600 dark:text-pink-400 border-pink-500/20",
 };
 
 interface ChatPanelProps {

--- a/frontend/src/components/GraphViewer.tsx
+++ b/frontend/src/components/GraphViewer.tsx
@@ -20,6 +20,7 @@ const NODE_COLORS: Record<string, string> = {
   Task: "#a855f7",
   Dataset: "#f97316",
   Author: "#64748b",
+  Repository: "#ec4899",
 };
 
 const DEFAULT_COLOR = "#64748b";

--- a/frontend/src/components/SearchResults.tsx
+++ b/frontend/src/components/SearchResults.tsx
@@ -7,7 +7,8 @@ const BADGE_COLORS: Record<string, string> = {
   Method: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20",
   Task: "bg-purple-500/10 text-purple-600 dark:text-purple-400 border-purple-500/20",
   Dataset: "bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/20",
-  Author: "bg-pink-500/10 text-pink-600 dark:text-pink-400 border-pink-500/20",
+  Author: "bg-slate-500/10 text-slate-600 dark:text-slate-400 border-slate-500/20",
+  Repository: "bg-pink-500/10 text-pink-600 dark:text-pink-400 border-pink-500/20",
 };
 
 interface SearchResultsProps {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -7,7 +7,7 @@
 
 // Shared types
 
-export type NodeLabel = "Paper" | "Method" | "Task" | "Dataset" | "Author";
+export type NodeLabel = "Paper" | "Method" | "Task" | "Dataset" | "Author" | "Repository";
 
 // Request
 


### PR DESCRIPTION
## Summary

- **4 new relationship types**: USES_METHOD (Paper→Method), ADDRESSES_TASK (Paper→Task), INTRODUCES_METHOD (Paper→Method), HAS_CODE (Paper→Repository)
- **Repository node type** with url, framework, stars, is_official properties
- **New node properties**: Paper (arxiv_id, url_pdf, date), Method (category, introduced_year), Dataset (num_papers, url)
- **Ingestion pipeline**: 2 new phases for USES_METHOD + ADDRESSES_TASK from papers.json, INTRODUCES_METHOD from methods.json
- **Graph retriever**: Fixed NETWORK Cypher template (ADDRESSES → ADDRESSES_TASK), added USES_METHOD traversal
- **Frontend**: Repository node visualization (pink color), updated badge colors and NodeLabel type

## Test plan

- [x] 18 new tests for edge parsers, new fields, updated mocks
- [x] 469 tests passing (3 pre-existing failures only)
- [x] Fixed stats mock to include Repository node count
- [ ] Run `make ingest` to populate new relationships (requires Neo4j)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)